### PR TITLE
Make --no-cache optional

### DIFF
--- a/modules/docker/Makefile.build
+++ b/modules/docker/Makefile.build
@@ -1,5 +1,6 @@
 ## Use DOCKER_IMAGE_NAME envvar to specify docker image with tags
 ## User ARGS to pass arguments
+DOCKER_BUILD_FLAGS ?= --no-cache
 
 .PHONY: docker\:build
 ## Build docker image
@@ -7,4 +8,4 @@ docker\:build: $(DOCKER)
 	@BUILD_ARGS=`for arg in $$ARGS; do \
 		printf -- '--build-arg %s=%s ' "$$arg" "$${!arg}"; \
 	done`; \
-	$(DOCKER) build --no-cache $$BUILD_ARGS -t $(DOCKER_IMAGE_NAME) .
+	$(DOCKER) build $(DOCKER_BUILD_FLAGS) $$BUILD_ARGS -t $(DOCKER_IMAGE_NAME) .


### PR DESCRIPTION
## what
* Define a new ENV called `DOCKER_BUILD_FLAGS` that lets you overwrite the default flags

## why
* The `--no-cache` option is great for CI, but tremendously slow for local development & iteration

## who
@goruha 