### PR TITLE
Add bash linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+script:
+  - "make bash:lint"

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
+BUILD_HARNESS_PATH ?= .
+
 include $(BUILD_HARNESS_PATH)/Makefile.*
 include $(BUILD_HARNESS_PATH)/modules/*/*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # build-harness
+

--- a/modules/bash/Makefile
+++ b/modules/bash/Makefile
@@ -1,0 +1,6 @@
+bash\:lint:
+	@set -o pipefail; \
+	(find . -type f -name '*.sh'; \
+	  grep -l -r '#!/bin/bash' .; \
+	  grep -l -r '#!/usr/bin/env bash' .; \
+	  grep -l -r '#!/bin/env bash' .) | grep -v 'Makefile' | sort -u | xargs -n 1 bash -n


### PR DESCRIPTION
## what
* Add a new `bash:lint` target that checks all bash scripts for syntax errors

## why
* Avoid accidentally breaking things

## demo
```
e@Quantum-2 ~/Dev/cloudposse/build-harness (master) $ make bash:lint
./bin/install.sh: line 13: syntax error: unexpected end of file
./foo: line 4: syntax error: unexpected end of file
make: *** [bash:lint] Error 1
```

## who
@goruha 