### PR TITLE
Derive Default App Name

### DIFF
--- a/modules/docs/Makefile.copyright
+++ b/modules/docs/Makefile.copyright
@@ -1,4 +1,5 @@
 COPYRIGHT_CMD ?= docker run --rm --volume `pwd`:$(COPYRIGHT_OUTPUT_DIR) osterman/copyright-header:latest
+COPYRIGHT_SOFTWARE ?= $(shell basename $(pwd))
 COPYRIGHT_LICENSE ?= ASL2
 COPYRIGHT_HOLDER ?= Cloud Posse, LLC <hello@cloudposse.com>
 COPYRIGHT_YEAR ?= $(shell date +%Y)

--- a/modules/docs/Makefile.copyright
+++ b/modules/docs/Makefile.copyright
@@ -1,5 +1,5 @@
 COPYRIGHT_CMD ?= docker run --rm --volume `pwd`:$(COPYRIGHT_OUTPUT_DIR) osterman/copyright-header:latest
-COPYRIGHT_SOFTWARE ?= $(shell basename $(pwd))
+COPYRIGHT_SOFTWARE ?= $(shell basename `pwd`)
 COPYRIGHT_LICENSE ?= ASL2
 COPYRIGHT_HOLDER ?= Cloud Posse, LLC <hello@cloudposse.com>
 COPYRIGHT_YEAR ?= $(shell date +%Y)

--- a/modules/go/Makefile.build
+++ b/modules/go/Makefile.build
@@ -1,7 +1,7 @@
 GLIDE	:= $(shell which glide)
 INSTALL_DIR ?= /usr/local/sbin
 RELEASE_DIR ?= release
-APP?=Example App
+APP ?= $(shell basename `pwd`)
 
 .PHONY: go\:build
 ## Build binary

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -2,10 +2,6 @@ SHELL = /bin/bash
 export BUILD_HARNESS_PATH ?= $(shell until [ -d "build-harness" ] || [ "`pwd`" == '/' ]; do cd ..; done; pwd)/build-harness
 -include $(BUILD_HARNESS_PATH)/Makefile
 
-####################### If go app ####################################################
-APP:=Example App
-######################################################################################
-
 .PHONY : init
 ## Init build-harness
 init:


### PR DESCRIPTION
## what
* determine default app name from current path
* still allow name to be overrridden

## why
* reduce copy/paste errors
* it's almost always going to correspond to the repo name

## who
@goruha 