### PR TITLE
Add Cross Platform Support to Helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BUILD_HARNESS_PATH ?= .
+OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 include $(BUILD_HARNESS_PATH)/Makefile.*
 include $(BUILD_HARNESS_PATH)/modules/*/*

--- a/modules/helm/Makefile
+++ b/modules/helm/Makefile
@@ -1,14 +1,14 @@
-CURL:= $(shell which curl)
-HELM_VERSION?=v2.1.3
-HELM_PLATFORM?=linux-amd64
-HELM:=$(shell which helm)
+CURL := $(shell which curl)
+HELM_VERSION ?= v2.2.0
+HELM_PLATFORM ?= $(OS)-amd64
+HELM := $(shell which helm)
 
 .PHONY: helm\:install
 ## Install helm
 helm\:install:
 	@$(CURL) https://kubernetes-helm.storage.googleapis.com/helm-$(HELM_VERSION)-$(HELM_PLATFORM).tar.gz | tar xvz
 	@chmod +x $(HELM_PLATFORM)/helm
-	@mv $(HELM_PLATFORM)/helm /usr/bin
+	@mv $(HELM_PLATFORM)/helm /usr/local/bin/
 	@helm init --client-only
 	@chmod -R 777 $(HOME)/.helm
 	@helm repo remove local || true

--- a/modules/helm/Makefile
+++ b/modules/helm/Makefile
@@ -11,6 +11,7 @@ helm\:install:
 	@mv $(HELM_PLATFORM)/helm /usr/bin
 	@helm init --client-only
 	@chmod -R 777 $(HOME)/.helm
+	@helm repo remove local || true
 
 .PHONY: helm\:serve\:index
 ## Build index for serve helm charts


### PR DESCRIPTION
## what
* Install `helm` based on OS
* Remote `local` repo by default
* Install to `/usr/local/bin`

## why
* Make it compatible with OSX
* `/usr/bin/` is read-only on OS X
* `local` repo is not used by cloudposse

## who
@cloudposse/engineering 