### PR TITLE
Force bash shell

### DIFF
--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -5,9 +5,11 @@ export BUILD_HARNESS_PATH ?= $(shell until [ -d "build-harness" ] || [ "`pwd`" =
 .PHONY : init
 ## Init build-harness
 init::
-	@curl --retry 5 --retry-delay 1 https://raw.githubusercontent.com/cloudposse/build-harness/master/bin/install.sh | bash
+	@curl --retry 5 --fail --silent --retry-delay 1 https://raw.githubusercontent.com/cloudposse/build-harness/master/bin/install.sh | bash
 
 .PHONY : clean
 ## Clean build-harness
 clean::
-	[ "$(BUILD_HARNESS_PATH)" == '/' ] || [ "$(BUILD_HARNESS_PATH)" == '.' ] || rm -rf $(BUILD_HARNESS_PATH)
+	@[ "$(BUILD_HARNESS_PATH)" == '/' ] || \
+	 [ "$(BUILD_HARNESS_PATH)" == '.' ] || \
+	   echo rm -rf $(BUILD_HARNESS_PATH)

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -1,14 +1,13 @@
-SHELL ?= /bin/bash
-
+export SHELL = /bin/bash
 export BUILD_HARNESS_PATH ?= $(shell until [ -d "build-harness" ] || [ "`pwd`" == '/' ]; do cd ..; done; pwd)/build-harness
 -include $(BUILD_HARNESS_PATH)/Makefile
 
 .PHONY : init
 ## Init build-harness
-init:
+init::
 	@curl --retry 5 --retry-delay 1 https://raw.githubusercontent.com/cloudposse/build-harness/master/bin/install.sh | bash
 
 .PHONY : clean
 ## Clean build-harness
-clean:
-	rm -rf $(BUILD_HARNESS_PATH)
+clean::
+	[ "$(BUILD_HARNESS_PATH)" == '/' ] || [ "$(BUILD_HARNESS_PATH)" == '.' ] || rm -rf $(BUILD_HARNESS_PATH)


### PR DESCRIPTION
## what
* enforce `SHELL=/bin/bash`
* do not `rm -rf /` or `rm -rf .`

## why
* There is a remote possibility that `BUILD_HARNESS_PATH` could be set to `/` or `.`
* Use bash because that is the way the `BUILD_HARNESS_PATH` discovery works (and it fails if not explicitly set to `/bin/bash`
* do not attempt to execute results from a non-200 response

## who
@goruha 