### PR TITLE
Restore Filesystem Permissions Before Building Docker Images

### DIFF
--- a/modules/docker/Makefile.build
+++ b/modules/docker/Makefile.build
@@ -7,7 +7,7 @@ DOCKER_BUILD_FLAGS ?= --no-cache
 docker\:build: $(DOCKER)
 	$(call assert-set,DOCKER)
 	$(call assert-set,DOCKER_IMAGE_NAME)
-	git permission-reset
+	git ls-files -s | awk '{print $1" "$4}' | sed s'/^..//' | xargs -n 2 echo chmod  | bash -x
 	@BUILD_ARGS=`for arg in $$ARGS; do \
 		printf -- '--build-arg %s=%s ' "$$arg" "$${!arg}"; \
 	done`; \

--- a/modules/docker/Makefile.build
+++ b/modules/docker/Makefile.build
@@ -7,6 +7,7 @@ DOCKER_BUILD_FLAGS ?= --no-cache
 docker\:build: $(DOCKER)
 	$(call assert-set,DOCKER)
 	$(call assert-set,DOCKER_IMAGE_NAME)
+	git permission-reset
 	@BUILD_ARGS=`for arg in $$ARGS; do \
 		printf -- '--build-arg %s=%s ' "$$arg" "$${!arg}"; \
 	done`; \

--- a/modules/docker/Makefile.build
+++ b/modules/docker/Makefile.build
@@ -7,7 +7,7 @@ DOCKER_BUILD_FLAGS ?= --no-cache
 docker\:build: $(DOCKER)
 	$(call assert-set,DOCKER)
 	$(call assert-set,DOCKER_IMAGE_NAME)
-	git ls-files -s | awk '{print $1" "$4}' | sed s'/^..//' | xargs -n 2 echo chmod  | bash -x
+	git ls-files -s | awk '{print $$1" "$$4}' | sed s'/^..//' | xargs --no-run-if-empty -n 2 echo chmod  | bash -x
 	@BUILD_ARGS=`for arg in $$ARGS; do \
 		printf -- '--build-arg %s=%s ' "$$arg" "$${!arg}"; \
 	done`; \

--- a/modules/git/Makefile
+++ b/modules/git/Makefile
@@ -5,3 +5,8 @@ GIT:= $(shell which git)
 git\:submodules-update:
 	$(call assert-set,GIT)
 	$(GIT) submodule update --init --remote
+
+.PHONY: git\:aliases-update
+## Update git aliases
+git\:aliases-update:
+	@$(GIT) config --global --add alias.permission-reset '!git diff -p -R --no-color | grep -E "^(diff|(old|new) mode)" --color=never | git apply'


### PR DESCRIPTION
## what
* change file modes back to what they were originally in git

## why
* some systems have crappy `umask` of `002` (e.g. travis). This results in all files having `-rwxrwx`. When building a docker image, that means files might be copied into the container with unsafe permissions.
  
## caveats
* `git` does not track directory permissions; this fix will not fix directory permissions

## who
@goruha 