### PR TITLE
Add a target to facilitate deployment to geodesic clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BUILD_HARNESS_PATH ?= .
 OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
+SELF ?= make
 
 include $(BUILD_HARNESS_PATH)/Makefile.*
 include $(BUILD_HARNESS_PATH)/modules/*/*

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Available targets:
   docker:login                        Login into docker hub
   docs:copyright-add                  Add copyright headers to source code
   docs:toc-update                     Update table of contents in README.md
+  geodesic:deploy                     Run a Jenkins Job to Deploy $(APP) with $(CANONICAL_TAG)
+  git:aliases-update                  Update git aliases
   git:submodules-update               Update submodules
   github:download-release             Download release from github
   go:build                            Build binary
@@ -57,6 +59,7 @@ Available targets:
   helm:repo:lint                      Lint charts
   helm:serve:index                    Build index for serve helm charts
   help                                This help screen
+  jenkins:run-job-with-tag            Run a Jenkins Job with $(TAG)
   make:lint                           Lint all makefiles
   travis:docker-tag-and-push          Tag according travis envvars and push
 ```

--- a/modules/geodesic/Makefile
+++ b/modules/geodesic/Makefile
@@ -1,0 +1,6 @@
+## Run a Jenkins Job to Deploy $(APP) with $(CANONICAL_TAG)
+geodesic\:deploy:
+	$(call assert-set,APP)
+	$(SELF) jenkins:run-job-with-tag \
+		JOB=deploy-$(APP) \
+		TAG=$(CANONICAL_TAG)

--- a/modules/geodesic/Makefile
+++ b/modules/geodesic/Makefile
@@ -1,6 +1,6 @@
 ## Run a Jenkins Job to Deploy $(APP) with $(CANONICAL_TAG)
 geodesic\:deploy:
 	$(call assert-set,APP)
-	$(SELF) jenkins:run-job-with-tag \
+	@$(SELF) jenkins:run-job-with-tag \
 		JOB=deploy-$(APP) \
 		TAG=$(CANONICAL_TAG)

--- a/modules/jenkins/Makefile
+++ b/modules/jenkins/Makefile
@@ -1,0 +1,15 @@
+export JENKINS_HOST ?= localhost
+export JENKINS_URL ?= https://$(JENKINS_HOST)/buildByToken/buildWithParameters
+
+# Depends on: https://wiki.jenkins-ci.org/display/JENKINS/Build+Token+Root+Plugin
+
+## Run a Jenkins Job with $(TAG)
+jenkins\:run-job-with-tag:
+	$(call assert-set,JENKINS_HOST)
+	$(call assert-set,JENKINS_URL)
+	$(call assert-set,TOKEN)
+	$(call assert-set,JOB)
+	$(call assert-set,TAG)
+	@echo "Running $(JOB) on $(JENKINS_HOST) with tag $(TAG)..."
+	@curl --fail --silent '$(JENKINS_URL) -d 'job=$(JOB)&token=$(TOKEN)&TAG=$(TAG)'
+

--- a/modules/jenkins/Makefile
+++ b/modules/jenkins/Makefile
@@ -11,5 +11,4 @@ jenkins\:run-job-with-tag:
 	$(call assert-set,JOB)
 	$(call assert-set,TAG)
 	@echo "Running $(JOB) on $(JENKINS_HOST) with tag $(TAG)..."
-	@curl --fail --silent '$(JENKINS_URL) -d 'job=$(JOB)&token=$(TOKEN)&TAG=$(TAG)'
-
+	@curl --fail '$(JENKINS_URL)' -d 'job=$(JOB)&token=$(TOKEN)&TAG=$(TAG)'

--- a/modules/travis/Makefile
+++ b/modules/travis/Makefile
@@ -1,0 +1,15 @@
+
+# Generate the canonical tag
+ifneq ($(TRAVIS_PULL_REQUEST_BRANCH),)
+  CANONICAL_TAG ?= pr-$(TRAVIS_PULL_REQUEST_BRANCH)-$(TRAVIS_BUILD_NUMBER)
+else ifneq ($(TRAVIS_BRANCH),)
+  CANONICAL_TAG ?= $(TRAVIS_BRANCH)-$(TRAVIS_BUILD_NUMBER)
+else ifneq ($(TRAVIS_TAG),)
+  CANONICAL_TAG ?= $(TRAVIS_TAG)-$(TRAVIS_BUILD_NUMBER)
+else
+  CANONICAL_TAG ?= $(shell git rev-parse --abbrev-ref HEAD)
+endif
+
+export CANONICAL_TAG
+
+


### PR DESCRIPTION
## what
* define a `CANONICAL_TAG` based on travis environment
* define a `jenkins:run-job-with-tag` target to call a Jenkins job passing it a `TAG` argument
* define a `geodesic:deploy` target that calls `jenkins:run-job-with-tag` passing it the standard ENVs that we use

## why
* facilitate CI/CD to kubernetes

## who
@goruha 