### PR TITLE
Download Public/Private GitHub Releases

### DIFF
--- a/bin/github_download_private_release.sh
+++ b/bin/github_download_private_release.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# github_download_private_release.sh! It works!
+#
+# Source https://gist.github.com/maxim/6e15aa45ba010ab030c4
+#
+# This script downloads an asset from latest or specific Github release of a
+# private repo. Feel free to extract more of the variables into command line
+# parameters.
+#
+# PREREQUISITES
+#
+# curl, wget, jq
+#
+# USAGE
+#
+# Set all the variables inside the script, make sure you chmod +x it, then
+# to download specific version to my_app.tar.gz:
+#
+#     github_download_private_release.sh 2.1.1 my_app.tar.gz
+#
+# to download latest version:
+#
+#     github_download_private_release.sh latest latest.tar.gz
+#
+# If your version/tag doesn't match, the script will exit with error.
+
+#GITHUB_TOKEN="<github_access_token>"
+#REPO="<user_or_org>/<repo_name>"
+#FILE="<name_of_asset_file>"      # the name of your release asset file, e.g. build.tar.gz
+VERSION=$1                       # tag name or the word "latest"
+GITHUB="https://api.github.com"
+
+alias errcho='>&2 echo'
+
+function gh_curl() {
+  curl -H "Authorization: token $GITHUB_TOKEN" \
+       -H "Accept: application/vnd.github.v3.raw" \
+       $@
+}
+
+if [ "$VERSION" = "latest" ]; then
+  # Github should return the latest release first.
+  parser=".[0].assets | map(select(.name == \"$FILE\"))[0].id"
+else
+  parser=". | map(select(.tag_name == \"$VERSION\"))[0].assets | map(select(.name == \"$FILE\"))[0].id"
+fi;
+
+asset_id=`gh_curl -s $GITHUB/repos/$REPO/releases | jq "$parser"`
+if [ "$asset_id" = "null" ]; then
+  echo "ERROR: version not found $VERSION"
+  exit 1
+fi;
+
+curl -H 'Accept:application/octet-stream' -o $2 -L  \
+  https://$GITHUB_TOKEN:@api.github.com/repos/$REPO/releases/assets/$asset_id

--- a/bin/github_download_public_release.sh
+++ b/bin/github_download_public_release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# github_download_release.sh! It works!
+# github_download_public_release.sh! It works!
 #
 # Source https://gist.github.com/maxim/6e15aa45ba010ab030c4
 #
@@ -17,15 +17,14 @@
 # Set all the variables inside the script, make sure you chmod +x it, then
 # to download specific version to my_app.tar.gz:
 #
-#     github_download_release.sh 2.1.1 my_app.tar.gz
+#     github_download_public_release.sh 2.1.1 my_app.tar.gz
 #
 # to download latest version:
 #
-#     github_download_release.sh latest latest.tar.gz
+#     github_download_public_release.sh latest latest.tar.gz
 #
 # If your version/tag doesn't match, the script will exit with error.
 
-#GITHUB_TOKEN="<github_access_token>"
 #REPO="<user_or_org>/<repo_name>"
 #FILE="<name_of_asset_file>"      # the name of your release asset file, e.g. build.tar.gz
 VERSION=$1                       # tag name or the word "latest"
@@ -34,8 +33,7 @@ GITHUB="https://api.github.com"
 alias errcho='>&2 echo'
 
 function gh_curl() {
-  curl -H "Authorization: token $GITHUB_TOKEN" \
-       -H "Accept: application/vnd.github.v3.raw" \
+  curl -H "Accept: application/vnd.github.v3.raw" \
        $@
 }
 
@@ -53,4 +51,4 @@ if [ "$asset_id" = "null" ]; then
 fi;
 
 curl -H 'Accept:application/octet-stream' -o $2 -L  \
-  https://$GITHUB_TOKEN:@api.github.com/repos/$REPO/releases/assets/$asset_id
+  https://api.github.com/repos/$REPO/releases/assets/$asset_id

--- a/modules/github/Makefile.release
+++ b/modules/github/Makefile.release
@@ -1,12 +1,23 @@
-.PHONY: github\:download-release
+.PHONY: github\:download-private-release
 ## GITHUB_TOKEN="<github_access_token>"
 ## REPO="<user_or_org>/<repo_name>"
 ## FILE="<name_of_asset_file>"      # the name of your release asset file, e.g. build.tar.gz
 ## Download release from github
-github\:download-release:
+github\:download-private-release:
 	$(call assert-set,GITHUB_TOKEN)
 	$(call assert-set,REPO)
 	$(call assert-set,FILE)
 	$(call assert-set,VERSION)
 	$(call assert-set,OUTPUT)
-	$(BUILD_HARNESS_PATH)/bin/github_download_release.sh $(VERSION) $(OUTPUT)
+	$(BUILD_HARNESS_PATH)/bin/github_download_private_release.sh $(VERSION) $(OUTPUT)
+
+.PHONY: github\:download-public-release
+## REPO="<user_or_org>/<repo_name>"
+## FILE="<name_of_asset_file>"      # the name of your release asset file, e.g. build.tar.gz
+## Download release from github
+github\:download-public-release:
+	$(call assert-set,REPO)
+	$(call assert-set,FILE)
+	$(call assert-set,VERSION)
+	$(call assert-set,OUTPUT)
+	$(BUILD_HARNESS_PATH)/bin/github_download_public_release.sh $(VERSION) $(OUTPUT)


### PR DESCRIPTION
## what
* Support downloading public & private GitHub releases

## why
* Public repos do not need Github Token

## caveats
* this is a breaking change; `github:download-release` deprecated

## who
@cloudposse/engineering 