### PR TITLE
Switch to getglide.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: go
 go:
   - 1.7.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
+language: go
+go:
+  - 1.7.x
+addons:
+  apt:
+    packages:
+    - git
+    - make
+    - curl
+
+install:
+- make init
+- make go:deps-build
+- make go:deps-dev
+
 script:
   - "make bash:lint"
   - "make make:lint"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 script:
   - "make bash:lint"
   - "make make:lint"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 script:
   - "make bash:lint"
   - "make make:lint"
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
     - curl
 
 install:
-- make init
 - make go:deps-build
 - make go:deps-dev
 

--- a/modules/go/Makefile.build
+++ b/modules/go/Makefile.build
@@ -27,7 +27,7 @@ go\:deps: $(GLIDE)
 go\:deps-build:
 	$(call assert-set,GOPATH)
 	mkdir -p  $(GOPATH)/bin
-	which $(GLIDE) || (curl https://glide.sh/get | sh)
+	which $(GLIDE) || (curl https://getglide.sh/get | sh)
 
 .PHONY: deps-dev
 ## Install development dependencies

--- a/modules/go/Makefile.build
+++ b/modules/go/Makefile.build
@@ -27,7 +27,7 @@ go\:deps: $(GLIDE)
 go\:deps-build:
 	$(call assert-set,GOPATH)
 	mkdir -p  $(GOPATH)/bin
-	which $(GLIDE) || (curl https://getglide.sh/get | sh)
+	which $(GLIDE) || (curl https://getglide.sh/get | sh -x)
 
 .PHONY: deps-dev
 ## Install development dependencies


### PR DESCRIPTION
## what
* Swap out `glide.sh` for `getglide.sh`
* Test that `go:deps-build` and `go:deps-dev` work
* Use `sudo: true` as a *hack* to avoid container based infrastructure on travis which leads to [rate limit](https://github.com/Masterminds/glide/issues?utf8=✓&q=is%3Aissue%20is%3Aopen%20rate%20limit) issues
* Use verbose output (`sh -x`) 

## why
* `glide.sh` expired and is pending deleted; problem with registrar getting it renewed
* https://github.com/Masterminds/glide/issues/784
* Verbose output enabled because when installing glide the script does not output accurate error messages when encountering GitHub rate limiting errors
* Using VMs instead of containers reduces likelihood of hitting GitHub rate limits because more containers share IPs that VMs.

## who
@goruha 