### PR TITLE
Restore glide.sh

### DIFF
--- a/modules/go/Makefile.build
+++ b/modules/go/Makefile.build
@@ -27,7 +27,7 @@ go\:deps: $(GLIDE)
 go\:deps-build:
 	$(call assert-set,GOPATH)
 	mkdir -p  $(GOPATH)/bin
-	which $(GLIDE) || (curl https://getglide.sh/get | sh -x)
+	which $(GLIDE) || (curl https://glide.sh/get | sh)
 
 .PHONY: deps-dev
 ## Install development dependencies


### PR DESCRIPTION
## what
* Use https://glide.sh/
* Disable verbose output (too verbose!)

## why
* Domain renewed

   ```
   Domain : glide.sh
   Status : Live
   Expiry : 2018-02-16
   
   NS 1   : carl.ns.cloudflare.com
   NS 2   : cass.ns.cloudflare.com
   
   Owner Name    : Matthew Farina
   Owner OrgName : Innovating Tomorrow, LLC
   Owner Addr    : 1779 La Salle Blvd
   Owner Addr    : Highland
   Owner Addr    : MI
   Owner Addr    : US
   ```
* DNS restored

   ```
   dig glide.sh

   ; <<>> DiG 9.8.3-P1 <<>> glide.sh
   ;; global options: +cmd
   ;; Got answer:
   ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 57158
   ;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0
   
   ;; QUESTION SECTION:
   ;glide.sh.			IN	A
   
   ;; ANSWER SECTION:
   glide.sh.		82	IN	A	104.28.17.133
   glide.sh.		82	IN	A	104.28.16.133
   ```

* Official domain


