### PR TITLE
Fix helm indexing

### DIFF
--- a/modules/helm/Makefile.repo
+++ b/modules/helm/Makefile.repo
@@ -84,7 +84,8 @@ helm\:repo\:package:
 helm\:repo\:index:
 	$(call assert-set,REPO_NAME)
 	@echo "## Generating index for $(CURRENT_REPO_URL)/$(REPO_NAME)"
-	@$(HELM) repo index $(PACKAGE_PATH) --url $(CURRENT_REPO_URL)/$(REPO_NAME) --debug
+	@$(CURL) $(CURRENT_REPO_URL)/$(REPO_NAME)/index.yaml $(PACKAGE_PATH)/index.yaml
+	@$(HELM) repo index $(PACKAGE_PATH) --merge --url $(CURRENT_REPO_URL)/$(REPO_NAME) --debug
 
 .PHONY : helm\:repo\:lint
 ## Lint charts

--- a/modules/helm/Makefile.repo
+++ b/modules/helm/Makefile.repo
@@ -84,8 +84,8 @@ helm\:repo\:package:
 helm\:repo\:index:
 	$(call assert-set,REPO_NAME)
 	@echo "## Generating index for $(CURRENT_REPO_URL)/$(REPO_NAME)"
-	@$(CURL) $(CURRENT_REPO_URL)/$(REPO_NAME)/index.yaml $(PACKAGE_PATH)/index.yaml
-	@$(HELM) repo index $(PACKAGE_PATH) --merge --url $(CURRENT_REPO_URL)/$(REPO_NAME) --debug
+	$(CURL) --fail -s -q $(CURRENT_REPO_URL)/$(REPO_NAME)/index.yaml -o /tmp/index.yaml
+	@$(HELM) repo index $(PACKAGE_PATH) --merge /tmp/index.yaml --url $(CURRENT_REPO_URL)/$(REPO_NAME) --debug
 
 .PHONY : helm\:repo\:lint
 ## Lint charts

--- a/modules/helm/Makefile.repo
+++ b/modules/helm/Makefile.repo
@@ -84,8 +84,12 @@ helm\:repo\:package:
 helm\:repo\:index:
 	$(call assert-set,REPO_NAME)
 	@echo "## Generating index for $(CURRENT_REPO_URL)/$(REPO_NAME)"
-	$(CURL) --fail -s -q $(CURRENT_REPO_URL)/$(REPO_NAME)/index.yaml -o /tmp/index.yaml
-	@$(HELM) repo index $(PACKAGE_PATH) --merge /tmp/index.yaml --url $(CURRENT_REPO_URL)/$(REPO_NAME) --debug
+	@$(CURL) --fail -s -q $(CURRENT_REPO_URL)/$(REPO_NAME)/index.yaml -o /tmp/index.yaml; \
+	if [ $$? -eq 0 ]; then \
+		$(HELM) repo index $(PACKAGE_PATH) --merge /tmp/index.yaml --url $(CURRENT_REPO_URL)/$(REPO_NAME) --debug; \
+	else \
+		$(HELM) repo index $(PACKAGE_PATH) --url $(CURRENT_REPO_URL)/$(REPO_NAME) --debug; \
+	fi; \
 
 .PHONY : helm\:repo\:lint
 ## Lint charts


### PR DESCRIPTION
## What
* Added merge option for helm repo index

## Why
* You need old index be merged with new index to preserve info about previous versions of chart