### PR TITLE
Update helm version to 2.3.1

### DIFF
--- a/modules/helm/Makefile
+++ b/modules/helm/Makefile
@@ -1,5 +1,5 @@
 CURL := $(shell which curl)
-HELM_VERSION ?= v2.2.0
+HELM_VERSION ?= v2.3.1
 HELM_PLATFORM ?= $(OS)-amd64
 HELM := $(shell which helm)
 


### PR DESCRIPTION
## What
* Update helm version to 2.3.1

## Why
* Helm used in travis builds