### PR TITLE
allow docker commands only for trusted builds in Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It's 100% Open Source and licensed under [APACHE2](LICENSE).
 At the top of your `Makefile` add, the following...
 
 ```make
--include $(shell curl -so .build-harness "https://raw.githubusercontent.com/cloudposse/build-harness/master/templates/Makefile.build-harness"; echo .build-harness)
+-include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
 ```
 
 This will download a `Makefile` called `.build-harness` and include it at run-time. We recommend adding the `.build-harness` file to your `.gitignore`.

--- a/modules/travis/Makefile.docker
+++ b/modules/travis/Makefile.docker
@@ -1,5 +1,32 @@
-.PHONY: travis\:docker-tag-and-push
+.PHONY: travis\:docker-login travis\:docker-tag-and-push
+
+# Allow docker actions on push to source repo or on PR's from trusted source only
+# check if we outside of Travis environment
+ifneq ($(TRAVIS), true)
+  ALLOW_DOCKER_ACTIONS := true
+# check if it’s not a pull request
+else ifeq ($(TRAVIS_PULL_REQUEST), false)
+  ALLOW_DOCKER_ACTIONS := true
+# check if pull request from originating repo
+else ifeq ($(TRAVIS_REPO_SLUG), $(TRAVIS_PULL_REQUEST_SLUG))
+  ALLOW_DOCKER_ACTIONS := true
+else
+  ALLOW_DOCKER_ACTIONS := false
+endif
+
+## Login into docker hub
+travis\:docker-login:
+ifeq ($(ALLOW_DOCKER_ACTIONS),true)
+	@make docker:login
+else
+	@echo "Skipping docker login for untrusted builds"
+endif
+
 ## Tag & Push according Travis environment variables
 travis\:docker-tag-and-push:
+ifeq ($(ALLOW_DOCKER_ACTIONS),true)
 	$(call assert-set,DOCKER_IMAGE_NAME)
 	$(BUILD_HARNESS_PATH)/bin/travis_docker_tag_and_push.sh
+else
+	@echo "Skipping docker tag and push for untrusted builds"
+endif

--- a/templates/docker.travis.yml
+++ b/templates/docker.travis.yml
@@ -11,7 +11,7 @@ services:
 - docker
 install:
 - make init
-- make docker:login
+- make travis:docker-login
 
 script:
 - make docker:build


### PR DESCRIPTION
# What

- added workflow to define Travis builds are trusted or not
- added conditions to target `travis:docker-tag-and-push` for trusted builds only
- added target `travis:docker-login` with conditions for trusted builds only
- added url shortner for `build-harness` and README updated
- template for `templates/docker.travis.yml` updated

# Why

- avoid run `docker login` and `docker push` commands for un-trusted builds in Travis (PR's from forks)