### PR TITLE
Check docker credentials in `docker:login`

### DIFF
--- a/.README.md
+++ b/.README.md
@@ -49,6 +49,7 @@ Here's how to get started...
 |
 {{- (datasource "contributor").erik }} |
 {{- (datasource "contributor").igor }} |
-|---|---|
+{{- (datasource "contributor").andriy }} |
+|---|---|---|
 
 {{ (datasource "contributor")._links }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 ./terraform
+.idea
+build-harness.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: go
 go:
-  - 1.7.x
+  - 1.9.x
 addons:
   apt:
     packages:

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2017-2018 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/modules/docker/Makefile.hub
+++ b/modules/docker/Makefile.hub
@@ -2,7 +2,10 @@
 ## Use DOCKER_HUB_USERNAME and DOCKER_HUB_PASSWORD env variables to pass credentials
 ## Login into docker hub
 docker\:login: $(DOCKER)
-	$(call assert-set,DOCKER)
-	$(call assert-set,DOCKER_HUB_USERNAME)
-	$(call assert-set,DOCKER_HUB_PASSWORD)
-	@$(DOCKER) login --username="$(DOCKER_HUB_USERNAME)" --password="$(DOCKER_HUB_PASSWORD)"
+#	$(call assert-set,DOCKER)
+#	$(call assert-set,DOCKER_HUB_USERNAME)
+#	$(call assert-set,DOCKER_HUB_PASSWORD)
+
+	@if [ -n "$DOCKER" ] && [ -n "$DOCKER_HUB_USERNAME" ] && [ -n "$DOCKER_HUB_PASSWORD" ]; then\
+    	@$(DOCKER) login --username="$(DOCKER_HUB_USERNAME)" --password="$(DOCKER_HUB_PASSWORD)";\
+    fi

--- a/modules/docker/Makefile.hub
+++ b/modules/docker/Makefile.hub
@@ -2,10 +2,8 @@
 ## Use DOCKER_HUB_USERNAME and DOCKER_HUB_PASSWORD env variables to pass credentials
 ## Login into docker hub
 docker\:login: $(DOCKER)
-#	$(call assert-set,DOCKER)
-#	$(call assert-set,DOCKER_HUB_USERNAME)
-#	$(call assert-set,DOCKER_HUB_PASSWORD)
-
 	@if [ -n "$DOCKER" ] && [ -n "$DOCKER_HUB_USERNAME" ] && [ -n "$DOCKER_HUB_PASSWORD" ]; then\
-    	@$(DOCKER) login --username="$(DOCKER_HUB_USERNAME)" --password="$(DOCKER_HUB_PASSWORD)";\
-    fi
+      @$(DOCKER) login --username="$(DOCKER_HUB_USERNAME)" --password="$(DOCKER_HUB_PASSWORD)";\
+	else \
+	  echo "Skipping docker:login. Docker credentials (DOCKER_HUB_USERNAME or DOCKER_HUB_PASSWORD) are not set"; \
+	fi;


### PR DESCRIPTION
## what
* Check `Docker` credentials in `docker:login`
* Don't login to `Docker` if credentials are missing

## why
* For external PRs (not originating from the original repo), for security reasons CI environments like `Travis` don't provide the ENV vars specified in repo Settings, and `Docker` login fails

```
$ make docker:login
DOCKER_HUB_USERNAME not defined in docker:login
make: *** [docker:login] Error 1
The command "make docker:login" failed and exited with 2 during .
```