### PR TITLE
Remove `()` from `bash` env vars

### DIFF
--- a/modules/docker/Makefile.hub
+++ b/modules/docker/Makefile.hub
@@ -3,7 +3,7 @@
 ## Login into docker hub
 docker\:login: $(DOCKER)
 	@if [ -n "$DOCKER" ] && [ -n "$DOCKER_HUB_USERNAME" ] && [ -n "$DOCKER_HUB_PASSWORD" ]; then\
-      $(DOCKER) login --username="$(DOCKER_HUB_USERNAME)" --password="$(DOCKER_HUB_PASSWORD)";\
+      $(DOCKER) login --username="$DOCKER_HUB_USERNAME" --password="$DOCKER_HUB_PASSWORD";\
 	else \
 	  echo "Skipping docker:login. Docker credentials (DOCKER_HUB_USERNAME or DOCKER_HUB_PASSWORD) are not set"; \
 	fi;


### PR DESCRIPTION
## what
* Remove `()` from `bash` env vars

## why
* Typo
