### PR TITLE
Fix `docker:login`

### DIFF
--- a/modules/docker/Makefile.hub
+++ b/modules/docker/Makefile.hub
@@ -2,8 +2,8 @@
 ## Use DOCKER_HUB_USERNAME and DOCKER_HUB_PASSWORD env variables to pass credentials
 ## Login into docker hub
 docker\:login: $(DOCKER)
-	@if [ -n "$DOCKER" ] && [ -n "$DOCKER_HUB_USERNAME" ] && [ -n "$DOCKER_HUB_PASSWORD" ]; then\
-      $(DOCKER) login --username="$DOCKER_HUB_USERNAME" --password="$DOCKER_HUB_PASSWORD";\
+	@if [ -n "$(DOCKER_HUB_USERNAME)" ] && [ -n "$(DOCKER_HUB_PASSWORD)" ]; then \
+      $(DOCKER) login --username="$(DOCKER_HUB_USERNAME)" --password="$(DOCKER_HUB_PASSWORD)"; \
 	else \
 	  echo "Skipping docker:login. Docker credentials (DOCKER_HUB_USERNAME or DOCKER_HUB_PASSWORD) are not set"; \
 	fi;


### PR DESCRIPTION
## what
* Fix `docker:login`

## why
* Incorrect ENV vars evaluation in the `shell` script inside `make` target
