### PR TITLE
Switch to Slashes in Make Targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ addons:
     - curl
 
 install:
-- make go:deps-build
-- make go:deps-dev
+- make go/deps-build
+- make go/deps-dev
 
 script:
-  - "make bash:lint"
-  - "make make:lint"
-  - "make terraform:install"
+  - "make bash/lint"
+  - "make make/lint"
+  - "make terraform/install"

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,11 @@ export BUILD_HARNESS_PATH ?= $(shell 'pwd')
 export OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 export SELF ?= make
 
+# Import Makefiles into current context
 include $(BUILD_HARNESS_PATH)/Makefile.*
 include $(BUILD_HARNESS_PATH)/modules/*/Makefile*
+
+ifndef TRANSLATE_COLON_NOTATION
+%:
+	@$(SELF) $(subst :,/,$@) TRANSLATE_COLON_NOTATION=false
+endif

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -27,7 +27,7 @@ default:: help
 ## This help screen
 help:
 	@printf "Available targets:\n\n"
-	@awk '/^[a-zA-Z\-\_0-9%:\\]+:/ { \
+	@awk '/^[a-zA-Z\-\_0-9%:\\\/]+:/ { \
 	  helpMessage = match(lastLine, /^## (.*)/); \
 	  if (helpMessage) { \
 	    helpCommand = $$1; \

--- a/README.md
+++ b/README.md
@@ -91,16 +91,16 @@ travis/docker-tag-and-push          Tag & Push according Travis environment vari
 
 **Got a question?**
 
-File a GitHub [issue](https://github.com/cloudposse/build-harness-git/issues), send us an [email](mailto:hello@cloudposse.com) or reach out to us on [Gitter](https://gitter.im/cloudposse/).
+File a GitHub [issue](https://github.com/cloudposse/build-harness/issues), send us an [email](mailto:hello@cloudposse.com) or reach out to us on [Gitter](https://gitter.im/cloudposse/).
 ## Contributing
 
 ### Bug Reports & Feature Requests
 
-Please use the [issue tracker](https://github.com/cloudposse/build-harness-git/issues) to report any bugs or file feature requests.
+Please use the [issue tracker](https://github.com/cloudposse/build-harness/issues) to report any bugs or file feature requests.
 
 ### Developing
 
-If you are interested in being a contributor and want to get involved in developing `build-harness-git`, we would love to hear from you! Shoot us an [email](mailto:hello@cloudposse.com).
+If you are interested in being a contributor and want to get involved in developing `build-harness`, we would love to hear from you! Shoot us an [email](mailto:hello@cloudposse.com).
 
 In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
@@ -114,8 +114,8 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 Here's how to get started...
 
-1. `git clone https://github.com/cloudposse/build-harness-git.git` to pull down the repository
-2. `make init` to initialize the [`build-harness-git`](https://github.com/cloudposse/build-harness-git/)
+1. `git clone https://github.com/cloudposse/build-harness.git` to pull down the repository
+2. `make init` to initialize the [`build-harness`](https://github.com/cloudposse/build-harness/)
 3. Review the [documentation](docs/) on compiling
 
 

--- a/README.md
+++ b/README.md
@@ -32,51 +32,52 @@ $ make help
 
   Available targets:
 
-bash:lint                           Lint all bash scripts
-docker:build                        Build docker image
-docker:login                        Login into docker hub
-docs:build                          Create $OUT file by building it from $IN template file
-docs:copyright-add                  Add copyright headers to source code
-docs:deps                           Install dependencies
-geodesic:deploy                     Run a Jenkins Job to Deploy $(APP) with $(CANONICAL_TAG)
-git:aliases-update                  Update git aliases
-github:download-private-release     Download release from github
-github:download-public-release      Download release from github
-git:submodules-update               Update submodules
-go:build                            Build binary
-go:build-all                        Build binary for all platforms
-go:clean                            Clean compiled binary
-go:clean-all                        Clean compiled binary and dependency
-go:deps                             Install dependencies
-go:deps-build                       Install dependencies for build
-go:deps-dev                         Install development dependencies
-go:fmt                              Format code according to Golang convention
-go:install                          Install cli
-go:lint                             Lint code
-go:test                             Run tests
-go:vet                              Vet code
-helm:install                        Install helm
-helm:repo:add-current               Add helm remote dev repos
-helm:repo:add-remote                Add helm remote repos
-helm:repo:build                     Build repo
-helm:repo:clean                     Clean helm repo
-helm:repo:fix-perms                 Fix repo filesystem permissions
-helm:repo:info                      Show repo info
-helm:repo:lint                      Lint charts
-helm:serve:index                    Build index for serve helm charts
+bash/lint                           Lint all bash scripts
+docker/build                        Build docker image
+docker/login                        Login into docker hub
+docs/build                          Create $OUT file by building it from $IN template file
+docs/copyright-add                  Add copyright headers to source code
+docs/deps                           Install dependencies
+geodesic/deploy                     Run a Jenkins Job to Deploy $(APP) with $(CANONICAL_TAG)
+git/aliases-update                  Update git aliases
+git/submodules-update               Update submodules
+github/download-private-release     Download release from github
+github/download-public-release      Download release from github
+go/build                            Build binary
+go/build-all                        Build binary for all platforms
+go/clean                            Clean compiled binary
+go/clean-all                        Clean compiled binary and dependency
+go/deps                             Install dependencies
+go/deps-build                       Install dependencies for build
+go/deps-dev                         Install development dependencies
+go/fmt                              Format code according to Golang convention
+go/install                          Install cli
+go/lint                             Lint code
+go/test                             Run tests
+go/vet                              Vet code
+helm/install                        Install helm
+helm/repo/add-current               Add helm remote dev repos
+helm/repo/add-remote                Add helm remote repos
+helm/repo/build                     Build repo
+helm/repo/clean                     Clean helm repo
+helm/repo/fix-perms                 Fix repo filesystem permissions
+helm/repo/info                      Show repo info
+helm/repo/lint                      Lint charts
+helm/serve/index                    Build index for serve helm charts
 help                                This help screen
-jenkins:run-job-with-tag            Run a Jenkins Job with $(TAG)
-make:lint                           Lint all makefiles
-readme:build                        Create README.md by building it from .README.md file
-readme:init                         Create basic minimalistic .README.md template file
-readme:toc-update                   Update table of contents in README.md
-terraform:get-modules               Ensure all modules can be fetched
-terraform:get-plugins               Ensure all plugins can be fetched
-terraform:install                   Install terraform
-terraform:lint                      Lint check Terraform
-terraform:validate                  Basic terraform sanity check
-travis:docker-login                 Login into docker hub
-travis:docker-tag-and-push          Tag & Push according Travis environment variables
+jenkins/run-job-with-tag            Run a Jenkins Job with $(TAG)
+make/lint                           Lint all makefiles
+readme/build                        Create README.md by building it from .README.md file
+readme/init                         Create basic minimalistic .README.md template file
+readme/toc-update                   Update table of contents in README.md
+terraform/get-modules               Ensure all modules can be fetched
+terraform/get-plugins               Ensure all plugins can be fetched
+terraform/install                   Install terraform
+terraform/lint                      Lint check Terraform
+terraform/validate                  Basic terraform sanity check
+test/me                             Test target
+travis/docker-login                 Login into docker hub
+travis/docker-tag-and-push          Tag & Push according Travis environment variables
 ```
 
 ## Real World Examples
@@ -90,16 +91,16 @@ travis:docker-tag-and-push          Tag & Push according Travis environment vari
 
 **Got a question?**
 
-File a GitHub [issue](https://github.com/cloudposse/build-harness/issues), send us an [email](mailto:hello@cloudposse.com) or reach out to us on [Gitter](https://gitter.im/cloudposse/).
+File a GitHub [issue](https://github.com/cloudposse/build-harness-git/issues), send us an [email](mailto:hello@cloudposse.com) or reach out to us on [Gitter](https://gitter.im/cloudposse/).
 ## Contributing
 
 ### Bug Reports & Feature Requests
 
-Please use the [issue tracker](https://github.com/cloudposse/build-harness/issues) to report any bugs or file feature requests.
+Please use the [issue tracker](https://github.com/cloudposse/build-harness-git/issues) to report any bugs or file feature requests.
 
 ### Developing
 
-If you are interested in being a contributor and want to get involved in developing `build-harness`, we would love to hear from you! Shoot us an [email](mailto:hello@cloudposse.com).
+If you are interested in being a contributor and want to get involved in developing `build-harness-git`, we would love to hear from you! Shoot us an [email](mailto:hello@cloudposse.com).
 
 In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
@@ -113,8 +114,8 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 Here's how to get started...
 
-1. `git clone https://github.com/cloudposse/build-harness.git` to pull down the repository
-2. `make init` to initialize the [`build-harness`](https://github.com/cloudposse/build-harness/)
+1. `git clone https://github.com/cloudposse/build-harness-git.git` to pull down the repository
+2. `make init` to initialize the [`build-harness-git`](https://github.com/cloudposse/build-harness-git/)
 3. Review the [documentation](docs/) on compiling
 
 
@@ -155,8 +156,8 @@ or [hire us][hire] to help build your next cloud-platform.
 
 ### Contributors
 
-|[![Erik Osterman][erik_img]][erik_web]<br/>[Erik Osterman][erik_web] |[![Igor Rodionov][igor_img]][igor_web]<br/>[Igor Rodionov][igor_img] |
-|---|---|
+|[![Erik Osterman][erik_img]][erik_web]<br/>[Erik Osterman][erik_web] |[![Igor Rodionov][igor_img]][igor_web]<br/>[Igor Rodionov][igor_img] |[![Andriy Knysh][andriy_img]][andriy_web]<br/>[Andriy Knysh][andriy_web] |
+|---|---|---|
 
 [andriy_img]: https://avatars0.githubusercontent.com/u/7356997?v=4&u=ed9ce1c9151d552d985bdf5546772e14ef7ab617&s=144
 [andriy_web]: https://github.com/aknysh/

--- a/bin/doc_generate.sh
+++ b/bin/doc_generate.sh
@@ -26,7 +26,7 @@ function array-merge {
 ## Example of usage
 ## module ./.README.md
 function modules {
-  grep -oP "(?<=datasource)\s+\".*?\"" $1 | sed 's/[ |\"]//g' | sort | uniq |  paste -sd " " -
+  grep -Eo '\(datasource ".*?"\)' "$1" |cut -d'"' -f2  | sort -u |  paste -sd " " -
 }
 
 ## Fire event $1 for all modules passed as args
@@ -55,7 +55,7 @@ function datasources {
   done
 }
 
-## Register modules
+## Register all documentation modules
 for file in $BUILD_HARNESS_PATH/modules/*/docs/*.sh ; do
   if [ -f "$file" ] ; then
     . "$file"

--- a/modules/bash/Makefile
+++ b/modules/bash/Makefile
@@ -1,5 +1,5 @@
 ## Lint all bash scripts
-bash\:lint:
+bash/lint:
 	@set -o pipefail; \
 	(find . -type f -name '*.sh'; \
 	  grep -l -r '#!/bin/bash' .; \

--- a/modules/docker/Makefile
+++ b/modules/docker/Makefile
@@ -1,4 +1,1 @@
 DOCKER:= $(shell which docker)
-
-default::
-	@exit 0

--- a/modules/docker/Makefile.build
+++ b/modules/docker/Makefile.build
@@ -4,9 +4,8 @@ DOCKER_BUILD_PATH ?= .
 DOCKER_BUILD_FLAGS ?= --no-cache
 DOCKER_FILE ?= ./Dockerfile
 
-.PHONY: docker\:build
 ## Build docker image
-docker\:build: $(DOCKER)
+docker/build: $(DOCKER)
 	$(call assert-set,DOCKER)
 	$(call assert-set,DOCKER_IMAGE_NAME)
 ifeq ($(TRAVIS),true)

--- a/modules/docker/Makefile.hub
+++ b/modules/docker/Makefile.hub
@@ -1,7 +1,6 @@
-.PHONY: docker\:login
 ## Use DOCKER_HUB_USERNAME and DOCKER_HUB_PASSWORD env variables to pass credentials
 ## Login into docker hub
-docker\:login: $(DOCKER)
+docker/login: $(DOCKER)
 	@if [ -n "$(DOCKER_HUB_USERNAME)" ] && [ -n "$(DOCKER_HUB_PASSWORD)" ]; then \
       $(DOCKER) login --username="$(DOCKER_HUB_USERNAME)" --password="$(DOCKER_HUB_PASSWORD)"; \
 	else \

--- a/modules/docs/Makefile
+++ b/modules/docs/Makefile
@@ -2,19 +2,15 @@ export GOMPLATE ?= $(BUILD_HARNESS_PATH)/vendor/gomplate
 GOMPLATE_VERSION ?= v2.2.0
 GOMPLATE_REPO ?= hairyhenderson/gomplate
 
-
 ## Install dependencies
-docs\:deps:
-	@make github:download-public-release \
+docs/deps:
+	@[ -f $(GOMPLATE) ] || $(SELF) github/download-public-release \
 		REPO=$(GOMPLATE_REPO) \
 		FILE=gomplate_$(OS)-amd64 \
 		VERSION=$(GOMPLATE_VERSION) \
 		OUTPUT=$(GOMPLATE) > /dev/null
 	@chmod +x $(GOMPLATE)
 
-
-
-.PHONY : docs\:build
 ## Create $OUT file by building it from $IN template file
-docs\:build:
+docs/build: docs/deps
 	@$(BUILD_HARNESS_PATH)/bin/doc_generate.sh

--- a/modules/docs/Makefile.copyright
+++ b/modules/docs/Makefile.copyright
@@ -6,9 +6,8 @@ COPYRIGHT_YEAR ?= $(shell date +%Y)
 COPYRIGHT_OUTPUT_DIR ?= /usr/src
 COPYRIGHT_WORD_WRAP ?= 100
 
-.PHONY : docs\:copyright-add
 ## Add copyright headers to source code
-docs\:copyright-add:
+docs/copyright-add:
 	$(call assert-set,COPYRIGHT_SOFTWARE)
 	$(call assert-set,COPYRIGHT_SOFTWARE_DESCRIPTION)
 	$(COPYRIGHT_CMD) \

--- a/modules/docs/docs/templates/contributor.yml
+++ b/modules/docs/docs/templates/contributor.yml
@@ -1,5 +1,5 @@
 ---
-  andrew: |-
+  andriy: |-
     [![Andriy Knysh][andriy_img]][andriy_web]<br/>[Andriy Knysh][andriy_web]
 
   erik: |-

--- a/modules/geodesic/Makefile
+++ b/modules/geodesic/Makefile
@@ -1,6 +1,6 @@
 ## Run a Jenkins Job to Deploy $(APP) with $(CANONICAL_TAG)
-geodesic\:deploy:
+geodesic/deploy:
 	$(call assert-set,APP)
-	@$(SELF) jenkins:run-job-with-tag \
+	@$(SELF) jenkins/run-job-with-tag \
 		JOB=deploy-$(APP) \
 		TAG=$(CANONICAL_TAG)

--- a/modules/git/Makefile
+++ b/modules/git/Makefile
@@ -1,12 +1,10 @@
 GIT:= $(shell which git)
 
-.PHONY: git\:submodules-update
 ## Update submodules
-git\:submodules-update:
+git/submodules-update:
 	$(call assert-set,GIT)
 	$(GIT) submodule update --init --remote
 
-.PHONY: git\:aliases-update
 ## Update git aliases
-git\:aliases-update:
+git/aliases-update:
 	@$(GIT) config --global --add alias.permission-reset '!git diff -p -R --no-color | grep -E "^(diff|(old|new) mode)" --color=never | git apply'

--- a/modules/git/docs/module.sh
+++ b/modules/git/docs/module.sh
@@ -9,7 +9,7 @@ function git_data-docs-prepare-data {
 cat << EOF > $GIT_DATA_FILE
 ---
   url: $(git ls-remote --get-url)
-  name: $(git ls-remote --get-url | grep -oP "(?<=\/).*(?=.git)")
+  name: $(basename `git rev-parse --show-toplevel`)
 EOF
 }
 

--- a/modules/git/docs/module.sh
+++ b/modules/git/docs/module.sh
@@ -9,7 +9,7 @@ function git_data-docs-prepare-data {
 cat << EOF > $GIT_DATA_FILE
 ---
   url: $(git ls-remote --get-url)
-  name: $(basename `git rev-parse --show-toplevel`)
+  name: $(basename -s .git `git ls-remote --get-url`)
 EOF
 }
 

--- a/modules/github/Makefile.release
+++ b/modules/github/Makefile.release
@@ -1,9 +1,8 @@
-.PHONY: github\:download-private-release
 ## GITHUB_TOKEN="<github_access_token>"
 ## REPO="<user_or_org>/<repo_name>"
 ## FILE="<name_of_asset_file>"      # the name of your release asset file, e.g. build.tar.gz
 ## Download release from github
-github\:download-private-release:
+github/download-private-release:
 	$(call assert-set,GITHUB_TOKEN)
 	$(call assert-set,REPO)
 	$(call assert-set,FILE)
@@ -11,11 +10,10 @@ github\:download-private-release:
 	$(call assert-set,OUTPUT)
 	$(BUILD_HARNESS_PATH)/bin/github_download_private_release.sh $(VERSION) $(OUTPUT)
 
-.PHONY: github\:download-public-release
 ## REPO="<user_or_org>/<repo_name>"
 ## FILE="<name_of_asset_file>"      # the name of your release asset file, e.g. build.tar.gz
 ## Download release from github
-github\:download-public-release:
+github/download-public-release:
 	$(call assert-set,REPO)
 	$(call assert-set,FILE)
 	$(call assert-set,VERSION)

--- a/modules/go/Makefile
+++ b/modules/go/Makefile
@@ -1,4 +1,1 @@
 GO:= $(shell which go)
-
-default::
-	@exit 0

--- a/modules/go/Makefile.build
+++ b/modules/go/Makefile.build
@@ -3,15 +3,13 @@ INSTALL_DIR ?= /usr/local/sbin
 RELEASE_DIR ?= release
 APP ?= $(shell basename `pwd`)
 
-.PHONY: go\:build
 ## Build binary
-go\:build: $(GO)
+go/build: $(GO)
 	$(call assert-set,GO)
 	$(GO) build -o $(RELEASE_DIR)/$(APP)
 
-.PHONY: go\:build-all
 ## Build binary for all platforms
-go\:build-all: $(GO)
+go/build-all: $(GO)
 	$(call assert-set,GO)
 ifeq ($(RELEASE_ARCH),)
 	gox -output "${RELEASE_DIR}/${APP}_{{.OS}}_{{.Arch}}"
@@ -19,23 +17,20 @@ else
 	gox -osarch="$(RELEASE_ARCH)" -output "${RELEASE_DIR}/${APP}_{{.OS}}_{{.Arch}}"
 endif
 
-.PHONY: go\:deps
 ## Install dependencies
-go\:deps: $(GLIDE)
+go/deps: $(GLIDE)
 	$(call assert-set,GLIDE)
 	$(GLIDE) install --strip-vendor
 	$(GLIDE) update  --strip-vendor
 
-.PHONY: go\:deps-build
 ## Install dependencies for build
-go\:deps-build:
+go/deps-build:
 	$(call assert-set,GOPATH)
 	mkdir -p  $(GOPATH)/bin
 	which $(GLIDE) || (curl https://glide.sh/get | sh)
 
-.PHONY: deps-dev
 ## Install development dependencies
-go\:deps-dev: $(GO)
+go/deps-dev: $(GO)
 	$(call assert-set,GO)
 	$(GO) get -d -v "github.com/golang/lint"
 	$(GO) install -v "github.com/golang/lint/golint"
@@ -43,15 +38,15 @@ go\:deps-dev: $(GO)
 	$(GO) install -v github.com/mitchellh/gox
 
 ## Clean compiled binary
-go\:clean:
+go/clean:
 	rm -rf $(RELEASE_DIR)
 
 ## Clean compiled binary and dependency
-go\:clean-all: go\:clean
+go/clean-all: clean
 	rm -rf vendor
 	rm -rf glide.lock
 
 ## Install cli
-go\:install: $(APP) go\:build
+go/install: $(APP) build
 	cp $(RELEASE_DIR)/$(APP) $(INSTALL_DIR)
 	chmod 555 $(INSTALL_DIR)/$(APP)

--- a/modules/go/Makefile.style
+++ b/modules/go/Makefile.style
@@ -1,17 +1,14 @@
-.PHONY: go\:lint
 ## Lint code
-go\:lint: $(GO) go\:vet
+go/lint: $(GO) vet
 	$(call assert-set,GO)
 	find . ! -path "*/vendor/*" ! -path "*/.glide/*" -type f -name '*.go' | xargs -n 1 golint
 
-.PHONY: go\:vet
 ## Vet code
-go\:vet: $(GO)
+go/vet: $(GO)
 	$(call assert-set,GO)
 	find . ! -path "*/vendor/*" ! -path "*/.glide/*" -type f -name '*.go' | xargs -n 1 $(GO) vet -v
 
-.PHONY: go\:fmt
 ## Format code according to Golang convention
-go\:fmt: $(GO)
+go/fmt: $(GO)
 	$(call assert-set,GO)
 	find . ! -path "*/vendor/*" ! -path "*/.glide/*" -type f -name '*.go' | xargs -n 1 gofmt -w -l -s

--- a/modules/go/Makefile.test
+++ b/modules/go/Makefile.test
@@ -1,6 +1,5 @@
-.PHONY: go\:test
 ## Run tests
-go\:test: $(GO)
+go/test: $(GO)
 	$(call assert-set,GO)
 ifneq ($(LINT),true)
 	$(GO) test $(shell $(GO) list ./... | grep -v /vendor/)

--- a/modules/helm/Makefile
+++ b/modules/helm/Makefile
@@ -3,9 +3,8 @@ HELM_VERSION ?= v2.7.2
 HELM_PLATFORM ?= $(OS)-amd64
 HELM := $(shell which helm)
 
-.PHONY: helm\:install
 ## Install helm
-helm\:install:
+helm/install:
 	@$(CURL) https://kubernetes-helm.storage.googleapis.com/helm-$(HELM_VERSION)-$(HELM_PLATFORM).tar.gz | tar xvz
 	@chmod +x $(HELM_PLATFORM)/helm
 	@mv $(HELM_PLATFORM)/helm /usr/local/bin/
@@ -13,10 +12,9 @@ helm\:install:
 	@chmod -R 777 $(HOME)/.helm
 	@helm repo remove local || true
 
-.PHONY: helm\:serve\:index
 ## Build index for serve helm charts
-helm\:serve\:index:
+helm/serve/index:
 	$(call assert-set,CURRENT_REPO_URL)
 	$(call assert-set,HELM)
-	@make helm:repo:index REPO_NAME=incubator
-	@make helm:repo:index REPO_NAME=stable
+	@$(SELF) helm:repo:index REPO_NAME=incubator
+	@$(SELF) helm:repo:index REPO_NAME=stable

--- a/modules/helm/Makefile.repo
+++ b/modules/helm/Makefile.repo
@@ -22,26 +22,23 @@ else
 	CURRENT_REPO_URL?=https://charts.dev.cloudposse.com/$(BRANCH)
 endif
 
-.PHONY : helm\:repo\:info
 ## Show repo info
-helm\:repo\:info:
+helm/repo/info:
 	@echo "REPO_URL: $(REPO_URL)"
 	@echo "CURRENT_REPO_URL: $(CURRENT_REPO_URL)"
 
-.PHONY: helm\:repo\:add-remote
 ## Add helm remote repos
-helm\:repo\:add-remote:
-	@make helm:repo:add \
+helm/repo/add-remote:
+	@$(SELF) helm/repo/add \
 		HELM_REPO_URL=$(REPO_URL)
 
-.PHONY: helm\:repo\:add-current
 ## Add helm remote dev repos
-helm\:repo\:add-current:
-	@make helm:repo:add \
+helm/repo/add-current:
+	@$(SELF) helm/repo/add \
 		HELM_REPO_PREFIX=$(HELM_REPO_PREFIX)-dev \
 		HELM_REPO_URL=$(CURRENT_REPO_URL)
 	
-helm\:repo\:add:
+helm/repo/add:
 	@$(HELM) repo add kubernetes-charts http://storage.googleapis.com/kubernetes-charts
 	@$(HELM) repo add opsgoodness http://charts.opsgoodness.com
 	@$(HELM) repo add kubernetes-charts-incubator https://kubernetes-charts-incubator.storage.googleapis.com
@@ -60,9 +57,8 @@ helm\:repo\:add:
 	@$(HELM) repo update
 	@$(HELM) repo list
 
-.PHONY : helm\:repo\:fix-perms
 ## Fix repo filesystem permissions
-helm\:repo\:fix-perms:
+helm/repo/fix-perms:
 	$(call assert-set,REPO_NAME)
 	@find $(REPO_PATH) -type f -name '*.yaml' -exec chmod 644 {} \;
 	@find $(REPO_PATH) -type f -name '*.txt' -exec chmod 644 {} \;
@@ -70,15 +66,13 @@ helm\:repo\:fix-perms:
 	@find $(REPO_PATH) -type f -name '*.md' -exec chmod 644 {} \;
 	@find $(REPO_PATH) -type f -name '*.tgz' -exec chmod 644 {} \;
 
-.PHONY : helm\:repo\:deps
-helm\:repo\:deps:
+helm/repo/deps:
 	$(call assert-set,REPO_NAME)
 	@echo "## Fetching deps for charts in $(shell basename $(CURDIR))"
 	@find $(REPO_PATH) -maxdepth 1 -mindepth 1 -type d  | \
     	xargs -n 1 -I '{}' sh -c 'echo && echo "# Updating dependencies for {}" && $(HELM) dependency build --debug {}'
 
-.PHONY : helm\:repo\:package
-helm\:repo\:package:
+helm/repo/package:
 	$(call assert-set,REPO_NAME)
 	@echo "## Building packages in $(shell basename $(CURDIR))"
 	@find $(REPO_PATH) -maxdepth 1 -mindepth 1 -type d  | \
@@ -87,8 +81,7 @@ helm\:repo\:package:
 	@find . -maxdepth 1 -mindepth 1 -type f -name '*.tgz' | \
 		xargs -I '{}' mv {} $(PACKAGE_PATH)
 
-.PHONY : helm\:repo\:index
-helm\:repo\:index:
+helm/repo/index:
 	$(call assert-set,REPO_NAME)
 	@echo "## Generating index for $(CURRENT_REPO_URL)/$(REPO_NAME)"
 	@$(CURL) --fail -s -q $(CURRENT_REPO_URL)/$(REPO_NAME)/index.yaml -o /tmp/index.yaml; \
@@ -98,31 +91,19 @@ helm\:repo\:index:
 		$(HELM) repo index $(PACKAGE_PATH) --url $(CURRENT_REPO_URL)/$(REPO_NAME) --debug; \
 	fi; \
 
-.PHONY : helm\:repo\:lint
 ## Lint charts
-helm\:repo\:lint:
+helm/repo/lint:
 	$(call assert-set,REPO_NAME)
 	@echo "## Linting charts $(shell pwd)"
 	@find $(REPO_PATH) -maxdepth 1 -mindepth 1 -type d | \
     	xargs -n 1 -I'{}' $(HELM) lint --strict {}
 
-
-.PHONY : helm\:repo\:clean
 ## Clean helm repo
-helm\:repo\:clean:
+helm/repo/clean:
 	$(call assert-set,REPO_NAME)
 	@rm -f *.tgz
 	@find $(REPO_PATH) -maxdepth 3 -mindepth 3 -type f -name '*.tgz' -delete
 	@rm -f $(PACKAGE_PATH)/*
 
-.PHONY : helm\:repo\:build
 ## Build repo
-helm\:repo\:build:
-	$(call assert-set,REPO_NAME)
-	@make helm:repo:clean
-	@make helm:repo:fix-perms
-	@make helm:repo:deps
-	@make helm:repo:lint
-	@make helm:repo:package
-
-
+helm/repo/build: helm/repo/clean helm/repo/fix-perms helm/repo/deps helm/repo/lint helm/repo/package

--- a/modules/jenkins/Makefile
+++ b/modules/jenkins/Makefile
@@ -4,7 +4,7 @@ export JENKINS_URL ?= https://$(JENKINS_HOST)/buildByToken/buildWithParameters
 # Depends on: https://wiki.jenkins-ci.org/display/JENKINS/Build+Token+Root+Plugin
 
 ## Run a Jenkins Job with $(TAG)
-jenkins\:run-job-with-tag:
+jenkins/run-job-with-tag:
 	$(call assert-set,JENKINS_HOST)
 	$(call assert-set,JENKINS_URL)
 	$(call assert-set,TOKEN)

--- a/modules/make/Makefile
+++ b/modules/make/Makefile
@@ -1,6 +1,6 @@
 ## Lint all makefiles
-make\:lint:
+make/lint:
 	@LINT=true \
 	 find . -type f -name 'Makefile*' -type f '!' -name '*.example' -exec \
 			 /bin/sh -c 'echo "==> {}">/dev/stderr; make --include-dir=modules/ --just-print --dry-run --recon --no-print-directory --quiet --silent -f {}' \; > /dev/null
-	@make bash:lint
+	@$(SELF) bash/lint

--- a/modules/readme/Makefile.docs
+++ b/modules/readme/Makefile.docs
@@ -1,14 +1,12 @@
 README_FILE ?= README.md
 README_TEMPLATE_NAME ?= .$(README_FILE)
 
-.PHONY : readme\:toc-update
 ## Update table of contents in README.md
-readme\:toc-update:
+readme/toc-update:
 	@doctoc --notitle --github $(README_FILE)
 
-.PHONY : readme\:init
 ## Create basic minimalistic .README.md template file
-readme\:init:
+readme/init:
 	@if [ -s ./$(README_TEMPLATE_FILE) ]; then \
 	  echo "$(README_TEMPLATE_FILE) already exists!"; \
 	else \
@@ -16,9 +14,6 @@ readme\:init:
 	  echo "$(README_FILE) created!"; \
 	fi;
 
-.PHONY : readme\:build
 ## Create README.md by building it from .README.md file
-readme\:build:
-	@IN=$(README_TEMPLATE_FILE) \
-	  OUT=$(README_FILE) \
-	  make -s docs:build
+readme/build:
+	@$(SELF) -s docs/build IN=$(README_TEMPLATE_FILE) OUT=$(README_FILE)

--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -3,10 +3,8 @@ TERRAFORM ?= $(BUILD_HARNESS_PATH)/vendor/terraform
 TERRAFORM_VERSION ?= 0.10.7
 TERRAFORM_URL ?= https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/terraform_$(TERRAFORM_VERSION)_$(OS)_amd64.zip
 
-
-
 ## Install terraform
-terraform\:install:
+terraform/install:
 	@[ -x $(TERRAFORM) ] || ( \
 		echo "Installing Terraform $(TERRAFORM_VERSION) ($(OS)) from $(TERRAFORM_URL)" && \
 		curl '-#' -fL -o $(TMP)/terraform.zip $(TERRAFORM_URL) && \
@@ -17,18 +15,18 @@ terraform\:install:
 	$(TERRAFORM) version
 
 ## Ensure all plugins can be fetched
-terraform\:get-plugins:
+terraform/get-plugins:
 	@$(TERRAFORM) init -get-plugins -backend=false -input=false >/dev/null
 
 ## Ensure all modules can be fetched
-terraform\:get-modules:
+terraform/get-modules:
 	@$(TERRAFORM) init -get -backend=false -input=false >/dev/null
 
 ## Basic terraform sanity check
-terraform\:validate:
+terraform/validate:
 	@$(TERRAFORM) validate -check-variables=false
 
 ## Lint check Terraform
-terraform\:lint:
+terraform/lint:
 	@FAIL=`$(TERRAFORM) fmt -write=false | xargs --no-run-if-empty -n 1 printf '\t- %s\n'`; \
 	[ -z "$$FAIL" ] || (echo "Terraform configuration needs linting. Run '$(TERRAFORM) fmt'"; echo $$FAIL; exit 1)

--- a/modules/terraform/docs/module.sh
+++ b/modules/terraform/docs/module.sh
@@ -9,14 +9,13 @@ TERRAFORM_DATA_FILE=$TMP/terraform_data.yml
 DATASOURCES[terraform]=file://$BUILD_HARNESS_PATH/modules/terraform/docs/templates/terraform.yml
 DATASOURCES[terraform_data]=file://$TERRAFORM_DATA_FILE
 
-
 function terraform-docs-prepare-data {
   if [ ! -s $TERRAFORM_DOCS ]; then
-    REPO=$TERRAFORM_DOCS_REPO \
-    FILE=terraform-docs_${OS}_amd64 \
-    VERSION=$TERRAFORM_DOCS_VERSION \
-    OUTPUT=$TERRAFORM_DOCS \
-    make github:download-public-release
+    make github/download-public-release \
+      REPO=$TERRAFORM_DOCS_REPO \
+      FILE=terraform-docs_${OS}_amd64 \
+      VERSION=$TERRAFORM_DOCS_VERSION \
+      OUTPUT=$TERRAFORM_DOCS
 
     chmod +x $TERRAFORM_DOCS
   fi;

--- a/modules/travis/Makefile
+++ b/modules/travis/Makefile
@@ -11,5 +11,3 @@ else
 endif
 
 export CANONICAL_TAG
-
-

--- a/modules/travis/Makefile.docker
+++ b/modules/travis/Makefile.docker
@@ -1,5 +1,3 @@
-.PHONY: travis\:docker-login travis\:docker-tag-and-push
-
 # Allow docker actions on push to source repo or on PR's from trusted source only
 # check if we outside of Travis environment
 ifneq ($(TRAVIS), true)
@@ -15,15 +13,15 @@ else
 endif
 
 ## Login into docker hub
-travis\:docker-login:
+travis/docker-login:
 ifeq ($(ALLOW_DOCKER_ACTIONS),true)
-	@make docker:login
+	@$(SELF) docker/login
 else
 	@echo "Skipping docker login for untrusted builds"
 endif
 
 ## Tag & Push according Travis environment variables
-travis\:docker-tag-and-push:
+travis/docker-tag-and-push:
 ifeq ($(ALLOW_DOCKER_ACTIONS),true)
 	$(call assert-set,DOCKER_IMAGE_NAME)
 	$(BUILD_HARNESS_PATH)/bin/travis_docker_tag_and_push.sh

--- a/templates/docker.travis.yml
+++ b/templates/docker.travis.yml
@@ -11,10 +11,10 @@ services:
 - docker
 install:
 - make init
-- make travis:docker-login
+- make travis/docker-login
 
 script:
-- make docker:build
+- make docker/build
 
 after_success:
-- make travis:docker-tag-and-push
+- make travis/docker-tag-and-push

--- a/templates/go.travis.yml
+++ b/templates/go.travis.yml
@@ -14,14 +14,14 @@ env:
 
 install:
 - make init
-- make go:deps-build
-- make go:deps-dev
+- make go/deps-build
+- make go/deps-dev
 
 script:
-- make go:deps
-- make go:test
-- make go:lint
-- make go:build-all
+- make go/deps
+- make go/test
+- make go/lint
+- make go/build-all
 
 deploy:
   provider: releases


### PR DESCRIPTION
## what
* Switch to using `/` in target names
* Support `:` in target names for backward compatibility
* Fix `readme/build` on OSX

## why
* `:` is not truly supported in make targets as they do not work when used as target dependencies
* `grep -P` not supported on BSD `grep` (OSX)

## example

this does not work:

```
test\:deps:
  echo "Hey"

test\:me: test:deps
```

This will not run `test:deps` and it silently skips it. Escaping the `:` in the dependency causes make error.


