### PR TITLE
Fix `make` targets

### DIFF
--- a/modules/go/Makefile.build
+++ b/modules/go/Makefile.build
@@ -41,11 +41,11 @@ go/clean:
 	rm -rf $(RELEASE_DIR)
 
 ## Clean compiled binary and dependency
-go/clean-all: clean
+go/clean-all: go/clean
 	rm -rf vendor
 	rm -rf glide.lock
 
 ## Install cli
-go/install: $(APP) build
+go/install: $(APP) go/build
 	cp $(RELEASE_DIR)/$(APP) $(INSTALL_DIR)
 	chmod 555 $(INSTALL_DIR)/$(APP)

--- a/modules/go/Makefile.style
+++ b/modules/go/Makefile.style
@@ -1,5 +1,5 @@
 ## Lint code
-go/lint: $(GO) vet
+go/lint: $(GO) go/vet
 	$(call assert-set,GO)
 	find . ! -path "*/vendor/*" ! -path "*/.glide/*" -type f -name '*.go' | xargs -n 1 golint
 

--- a/modules/helm/Makefile.repo
+++ b/modules/helm/Makefile.repo
@@ -14,9 +14,9 @@ else
 endif
 
 ifeq ($(BRANCH),master)
-	CURRENT_REPO_URL?=$(REPO_URL)
+  CURRENT_REPO_URL?=$(REPO_URL)
 else
-	CURRENT_REPO_URL?=https://charts.dev.cloudposse.com/$(BRANCH)
+  CURRENT_REPO_URL?=https://charts.dev.cloudposse.com/$(BRANCH)
 endif
 
 ## Show repo info

--- a/modules/semver/Makefile
+++ b/modules/semver/Makefile
@@ -12,9 +12,9 @@ SEMVERSIONS += $(SEMVERSION_COMMIT)
 ## If we are on git tag. ex.: 0.3.1
 SEMVERSION_TAG =
 ifeq ($(GIT_IS_TAG),1)
-	## Version based on tag. ex.: 0.3.1
-	SEMVERSION_TAG = $(GIT_LATEST_TAG)
-	SEMVERSIONS += $(SEMVERSION_TAG)
+  ## Version based on tag. ex.: 0.3.1
+  SEMVERSION_TAG = $(GIT_LATEST_TAG)
+  SEMVERSIONS += $(SEMVERSION_TAG)
 endif
 
 ## If we are on git branch. ex.: master
@@ -22,17 +22,17 @@ SEMVERSION_BRANCH=
 SEMVERSION_BRANCH_COMMIT_SHORT=
 SEMVERSION_BRANCH_COMMIT=
 ifeq ($(GIT_IS_BRANCH),1)
-	## Version based on branch. ex.: 0.3.1-master
-	SEMVERSION_BRANCH = $(GIT_LATEST_TAG)-$(GIT_BRANCH)
-	SEMVERSIONS += $(SEMVERSION_BRANCH)
+  ## Version based on branch. ex.: 0.3.1-master
+  SEMVERSION_BRANCH = $(GIT_LATEST_TAG)-$(GIT_BRANCH)
+  SEMVERSIONS += $(SEMVERSION_BRANCH)
 
-	## Version based on branch and short commit. ex.: 0.3.1-master.sha.80b9f6f
-	SEMVERSION_BRANCH_COMMIT_SHORT = $(GIT_LATEST_TAG)-$(GIT_BRANCH).sha.$(GIT_COMMIT_SHORT)
-	SEMVERSIONS += $(SEMVERSION_BRANCH_COMMIT_SHORT)
+  ## Version based on branch and short commit. ex.: 0.3.1-master.sha.80b9f6f
+  SEMVERSION_BRANCH_COMMIT_SHORT = $(GIT_LATEST_TAG)-$(GIT_BRANCH).sha.$(GIT_COMMIT_SHORT)
+  SEMVERSIONS += $(SEMVERSION_BRANCH_COMMIT_SHORT)
 
-	## Version based on branch and long commit. ex.: 0.3.1-master.sha.80b9f6f5b965555e406b9db066a8e16cb1075e5f
-	SEMVERSION_BRANCH_COMMIT = $(GIT_LATEST_TAG)-$(GIT_BRANCH).sha.$(GIT_COMMIT)
-	SEMVERSIONS += $(SEMVERSION_BRANCH_COMMIT)
+  ## Version based on branch and long commit. ex.: 0.3.1-master.sha.80b9f6f5b965555e406b9db066a8e16cb1075e5f
+  SEMVERSION_BRANCH_COMMIT = $(GIT_LATEST_TAG)-$(GIT_BRANCH).sha.$(GIT_COMMIT)
+  SEMVERSIONS += $(SEMVERSION_BRANCH_COMMIT)
 endif
 
 ## Use as default version first of possible versions

--- a/modules/stages/Makefile
+++ b/modules/stages/Makefile
@@ -1,15 +1,15 @@
 FEATURE_PATTERN ?= "^feature-\d*"
 
 ifeq ($(GIT_IS_TAG),1)
-	FEATURE ?= $(GIT_LATEST_TAG)
+  FEATURE ?= $(GIT_LATEST_TAG)
 endif
 
 ifeq ($(GIT_IS_BRANCH),1)
-	ifneq ($(shell echo $(GIT_BRANCH) | grep -Po $(FEATURE_PATTERN)),)
-		FEATURE ?= $(shell echo $(GIT_BRANCH) | grep -Po $(FEATURE_PATTERN))
-	else
-		FEATURE ?= "$(GIT_BRANCH)"
-	endif
+  ifneq ($(shell echo $(GIT_BRANCH) | grep -Po $(FEATURE_PATTERN)),)
+    FEATURE ?= $(shell echo $(GIT_BRANCH) | grep -Po $(FEATURE_PATTERN))
+  else
+    FEATURE ?= "$(GIT_BRANCH)"
+  endif
 endif
 
 ## Export stages vars


### PR DESCRIPTION
## what
* Fix `make` targets

## why
* Wrong dependencies 
* Throws errors like this:

```
$ make go/lint
make[1]: Entering directory `/home/travis/gopath/src/github.com/cloudposse/github-commenter'
make[1]: *** No rule to make target `vet'.  Stop.
make[1]: Leaving directory `/home/travis/gopath/src/github.com/cloudposse/github-commenter'
make: *** [vet] Error 2
```