### PR TITLE
Fix `Go` make targets

### DIFF
--- a/modules/go/Makefile.build
+++ b/modules/go/Makefile.build
@@ -32,9 +32,8 @@ go/deps-build:
 ## Install development dependencies
 go/deps-dev: $(GO)
 	$(call assert-set,GO)
-	$(GO) get -u -d -v "golang.org/x/lint/golint"
-	$(GO) get -d -v github.com/mitchellh/gox
-	$(GO) install -v github.com/mitchellh/gox
+	$(GO) get -u -v golang.org/x/lint/golint
+	$(GO) get -u -v github.com/mitchellh/gox
 
 ## Clean compiled binary
 go/clean:

--- a/modules/go/Makefile.style
+++ b/modules/go/Makefile.style
@@ -6,7 +6,7 @@ go/lint: $(GO) go/vet
 ## Vet code
 go/vet: $(GO)
 	$(call assert-set,GO)
-	find . ! -path "*/vendor/*" ! -path "*/.glide/*" -type f -name '*.go' | xargs -n 1 $(GO) vet -v
+	find . ! -path "*/vendor/*" ! -path "*/.glide/*" -type f -name '*.go' | xargs $(GO) vet -v
 
 ## Format code according to Golang convention
 go/fmt: $(GO)


### PR DESCRIPTION
## what
* Provide all `.go` files at once to `go vet`
* Remove `-d` flag from `go get`
* Install `golint`


## why
* If `.go` files provided sequentially to `go vet`, it couldn't find dependencies throwing the error:
```
make[1]: Entering directory `/home/travis/gopath/src/github.com/cloudposse/slack-notifier'
find . ! -path "*/vendor/*" ! -path "*/.glide/*" -type f -name '*.go' | xargs -n 1 /home/travis/.gimme/versions/go1.9.4.linux.amd64/bin/go vet -v
Checking file slack_notifier.go
main.go:45:24: undeclared name: Field
```

* `go get` installs packages automatically (if `-d` flag is not specified)
* `golint` was just downloaded, but not installed
```
find . ! -path "*/vendor/*" ! -path "*/.glide/*" -type f -name '*.go' | xargs -n 1 golint
xargs: golint: No such file or directory
```

## references
* https://golang.org/cmd/go/
* https://github.com/golang/lint

