### PR TITLE
Fix `make readme`

### DIFF
--- a/bin/template_generate.sh
+++ b/bin/template_generate.sh
@@ -16,9 +16,9 @@ INCLUDED_MODULES=()
 function array-merge {
   # Declare an associative array
   declare -A tmp
-  # Store the values of arr3 in arr4 as keys.
+  # Store the values of arr3 in arr4 as keys
   for k in $@; do tmp["$k"]=1; done
-  # Extract the keys.
+  # Extract the keys
   echo "${!tmp[@]}"
 }
 
@@ -31,7 +31,7 @@ function modules {
 
 ## Fire event $1 for all modules passed as args
 ## Example of usage
-## fire event "test" "git" "make"
+## fire_event "test" "git" "make"
 ## Will call functions "git-test" and "make-test" if exists
 function fire_event {
   local event=$1
@@ -46,7 +46,7 @@ function fire_event {
   done
 }
 
-## Provde datasource options for modules passed as args
+## Provide datasource options for modules passed as args
 ## Example of usage
 ## datasources "git" "make"
 function datasources {
@@ -67,7 +67,7 @@ MODULES=$(modules $IN)
 
 until [ -z "$MODULES" ]
 do
-  ## Merge modules list with modules from previous iteration
+  ## Merge module list with modules from previous iteration
   INCLUDED_MODULES=$( array-merge $INCLUDED_MODULES $MODULES)
   ## Prepare data for just found modules
   fire_event "template-prepare-data" $MODULES
@@ -76,7 +76,7 @@ do
 
   ## For all iterations (except first) use $OUT file as $IN template to replace recursive placeholders
   IN=$OUT
-  ## Find modules in $IN file for next interation.
+  ## Find modules in $IN file for the next iteration
   MODULES=$(modules $IN)
 done
 
@@ -86,6 +86,3 @@ fire_event "template-cleanup-data" $INCLUDED_MODULES
 rm -rf $TMP
 
 echo "$OUT generated"
-
-
-

--- a/modules/readme/Makefile
+++ b/modules/readme/Makefile
@@ -14,8 +14,8 @@ readme/init:
 	@if [ -s ./$(README_TEMPLATE_FILE) ]; then \
 	  echo "$(README_TEMPLATE_FILE) already exists!"; \
 	else \
-	  cp $(BUILD_HARNESS_PATH)/templates/$(README_TEMPLATE_FILE) ./$(README_FILE) ; \
-	  echo "$(README_FILE) created!"; \
+	  cp $(BUILD_HARNESS_PATH)/templates/$(README_TEMPLATE_FILE) ./$(README_TEMPLATE_FILE) ; \
+	  echo "$(README_TEMPLATE_FILE) created!"; \
 	fi;
 
 ## Create README.md by building it from .README.md file

--- a/modules/template/Makefile
+++ b/modules/template/Makefile
@@ -12,5 +12,5 @@ template/deps:
 	@chmod +x $(GOMPLATE)
 
 ## Create $OUT file by building it from $IN template file
-template/build:
+template/build: template/deps
 	@$(BUILD_HARNESS_PATH)/bin/template_generate.sh


### PR DESCRIPTION
## what
* Fix `readme/init` target
* `template/build` target explicitly depends on `template/deps`  target
* Fix typos

## why
* Wrong output file name in `readme/init`
* Nobody knows that they need to call `template/deps` to install `gomplate` when calling `make readme` (`gomplate` is ignored in `vendor/.gitignore`)
