### PR TITLE
Disable strict mode for helm lint

### DIFF
--- a/modules/helm/Makefile.repo
+++ b/modules/helm/Makefile.repo
@@ -110,7 +110,7 @@ helm/repo/lint:
 	$(call assert-set,REPO_NAME)
 	@echo "## Linting charts $(shell pwd)"
 	@find $(HELM_REPO_PATH) -maxdepth 1 -mindepth 1 -type d | \
-    	xargs -n 1 -I'{}' $(HELM) lint --strict {}
+    	xargs -n 1 -I'{}' $(HELM) lint {}
 
 ## Clean helm repo
 helm/repo/clean:


### PR DESCRIPTION
## What
* Disable strict mode for helm lint

## Why
* It pay attention to non existed values in `values.yaml` like `fullnameOverride`
But `fullnameOverride` is a pattern for chart naming and should not be defined in `values.yaml`
The same case with `global` values

```
✅   (assume-role staging:39m) portal ➤  helm lint --strict
==> Linting .
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/: render error in "portal/templates/proxy.service.yaml": template: portal/templates/proxy.service.yaml:5:11: executing "portal/templates/proxy.service.yaml" at <include "portal.prox...>: error calling include: template: portal/charts/common/templates/_fullname.tpl:21:39: executing "common.fullname" at <.Values.global>: map has no entry for key "global"
```