### PR TITLE
add libc6-compat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk update && \
       gettext \
       grep \
       jq \
+      libc6-compat \
       make
 
 ADD ./ /build-harness/


### PR DESCRIPTION
## what
* Add `libc6-compat`

## why
* Needed by `helmfile` and many other binaries