### PR TITLE
Add target to delete helm namespace and trigger codefresh webhook

### DIFF
--- a/modules/codefresh/Makefile
+++ b/modules/codefresh/Makefile
@@ -1,0 +1,15 @@
+CF_TRIGGER_TYPE ?= build
+CF_TRIGGER_REPO_NAME ?= $(CF_REPO_NAME)
+CF_TRIGGER_BRANCH ?= $(CF_BRANCH)
+CF_TRIGGER_REPO_OWNER ?= $(CF_REPO_OWNER)
+
+## Trigger a CodeFresh WebHook
+codefresh/trigger/webhook:
+	@curl 'https://g.codefresh.io/api/builds/$(CF_TRIGGER_SERVICE_ID)' \
+	 --compressed \
+	 -H 'content-type:application/json; charset=utf-8' \
+	 -H 'x-access-token: $(CF_ACCESS_TOKEN)' \
+	 --data-binary \
+		'{"serviceId":"$(CF_TRIGGER_SERVICE_ID)","type":"$(CF_TRIGGER_TYPE)","repoOwner":"$(CF_TRIGGER_REPO_OWNER)","branch":"$(CF_TRIGGER_BRANCH)","repoName":"$(CF_TRIGGER_REPO_NAME)"}'
+
+

--- a/modules/helm/Makefile
+++ b/modules/helm/Makefile
@@ -23,3 +23,7 @@ helm/serve/index:
 helm/toolbox/upsert:
 	@$(BUILD_HARNESS_PATH)/bin/helm_toolbox.sh upsert
 
+## Delete all releases in a namespace as well as the namespace
+helm/delete/namespace:
+	@helm list --namespace $(NAMESPACE) --short | xargs helm delete --purge
+	@kubectl delete namespace $(NAMESPACE) --ignore-not-found


### PR DESCRIPTION
## what
* Add `codefresh/trigger/webhook` target
* Add `helm/delete/namespace` target

## why
* Easily trigger pipelines from other pipelines
* Easily destroy namespaces when PRs are closed