### PR TITLE
Helm - bump version

### DIFF
--- a/modules/helm/Makefile
+++ b/modules/helm/Makefile
@@ -1,5 +1,5 @@
 CURL ?= curl
-export HELM_VERSION ?= 2.9.0
+export HELM_VERSION ?= 2.9.1
 HELM_PLATFORM ?= $(OS)-amd64
 HELM ?= helm
 HELM_HOME ?= $(HOME)/.helm


### PR DESCRIPTION
## what
* use helm 2.9.1

## why
* #64 