### PR TITLE
Delete failed releases

### DIFF
--- a/modules/helm/Makefile
+++ b/modules/helm/Makefile
@@ -23,7 +23,11 @@ helm/serve/index:
 helm/toolbox/upsert:
 	@$(BUILD_HARNESS_PATH)/bin/helm_toolbox.sh upsert
 
-## Delete all releases in a namespace as well as the namespace
+## Delete all releases in a `NAMEPSACE` as well as the namespace
 helm/delete/namespace:
 	@helm list --namespace $(NAMESPACE) --short | xargs helm delete --purge
 	@kubectl delete namespace $(NAMESPACE) --ignore-not-found
+
+## Delete all failed releases in a `NAMESPACE` subject to `FILTER`
+helm/delete/failed:
+	@helm list --namespace $(NAMESPACE) --failed --short $(FILTER) 2>/dev/null | xargs helm delete --purge


### PR DESCRIPTION
## what
* Add a make target to easily delete failed helm releases

## why
* `helm upgrade` fails if there's previously a failed release
* In unlimited staging environments, it's convenient to delete previously failed releases to reduce CI/CD failures

## usage
```
make helm/delete/failed NAMESPACE=foo FILTER=the-release-name
```