### PR TITLE
Fix helm delete

### DIFF
--- a/modules/helm/Makefile
+++ b/modules/helm/Makefile
@@ -25,9 +25,9 @@ helm/toolbox/upsert:
 
 ## Delete all releases in a `NAMEPSACE` as well as the namespace
 helm/delete/namespace:
-	@helm list --namespace $(NAMESPACE) --short | xargs helm delete --purge
+	@helm list --namespace $(NAMESPACE) --short | xargs -r helm delete --purge
 	@kubectl delete namespace $(NAMESPACE) --ignore-not-found
 
 ## Delete all failed releases in a `NAMESPACE` subject to `FILTER`
 helm/delete/failed:
-	@helm list --namespace $(NAMESPACE) --failed --short $(FILTER) 2>/dev/null | xargs helm delete --purge
+	@helm list --namespace $(NAMESPACE) --failed --short $(FILTER) 2>/dev/null | xargs -r helm delete --purge


### PR DESCRIPTION
## what
* Fails when no failed releases

## why
* helm delete should not be run when on releases to delete

(`-r` means "don't run if empty" for `alpine` version of `xargs`)