### PR TITLE
Fix template. Link to footnotes broken.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Cloud Posse](https://cloudposse.com/logo-300x69.svg)](https://cloudposse.com)
 
-# Build Harness [![Build Status](https://travis-ci.org/cloudposse/build-harness.svg?branch=master)](https://travis-ci.org/cloudposse/build-harness) [![Latest Release](https://img.shields.io/github/release/cloudposse/build-harness.svg)](https://github.com/cloudposse/build-harness/releases) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+# Build Harness [![Build Status](https://travis-ci.org/cloudposse/build-harness.svg?branch=master)](https://travis-ci.org/cloudposse/build-harness) [![Latest Release](https://img.shields.io/github/release/cloudposse/build-harness.svg)](https://github.com/cloudposse/build-harness/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 
 
 This `build-harness` is a collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more.
@@ -270,7 +270,7 @@ Check out [our other projects][github], [apply for a job][jobs], or [hire us][hi
 
 ### Contributors
 
-|  [![Erik Osterman][osterman_avatar]](osterman_homepage)<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]](goruha_homepage)<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]](aknysh_homepage)<br/>[Andriy Knysh][aknysh_homepage] | [![Konstantin][comeanother_avatar]](comeanother_homepage)<br/>[Konstantin][comeanother_homepage] | [![Sergey][s2504s_avatar]](s2504s_homepage)<br/>[Sergey][s2504s_homepage] | [![Valeriy][drama17_avatar]](drama17_homepage)<br/>[Valeriy][drama17_homepage] | [![Vladimir][SweetOps_avatar]](SweetOps_homepage)<br/>[Vladimir][SweetOps_homepage] |
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Konstantin][comeanother_avatar]][comeanother_homepage]<br/>[Konstantin][comeanother_homepage] | [![Sergey][s2504s_avatar]][s2504s_homepage]<br/>[Sergey][s2504s_homepage] | [![Valeriy][drama17_avatar]][drama17_homepage]<br/>[Valeriy][drama17_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] |
 |---|---|---|---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman

--- a/README.yaml
+++ b/README.yaml
@@ -29,7 +29,7 @@ badges:
     url: "https://travis-ci.org/cloudposse/build-harness"
   - name: "Latest Release"
     image: "https://img.shields.io/github/release/cloudposse/build-harness.svg"
-    url: "https://github.com/cloudposse/build-harness/releases"
+    url: "https://github.com/cloudposse/build-harness/releases/latest"
   - name: "Slack Community"
     image: "https://slack.cloudposse.com/badge.svg"
     url: "https://slack.cloudposse.com"

--- a/templates/README.md
+++ b/templates/README.md
@@ -206,7 +206,7 @@ Check out [our other projects][github], [apply for a job][jobs], or [hire us][hi
 {{ if has (datasource "config") "contributors" }}
 ### Contributors
 
-| {{ range $contributor := (ds "config").contributors }}{{ printf " [![%s][%s_avatar]](%s_homepage)<br/>[%s][%s_homepage] |" $contributor.name $contributor.github $contributor.github $contributor.name $contributor.github}}{{ end }}
+| {{ range $contributor := (ds "config").contributors }}{{ printf " [![%s][%s_avatar]][%s_homepage]<br/>[%s][%s_homepage] |" $contributor.name $contributor.github $contributor.github $contributor.name $contributor.github}}{{ end }}
 |{{- range $contributor := (ds "config").contributors -}}---|{{ end }}
 
 {{ range $contributor := (ds "config").contributors -}}


### PR DESCRIPTION
### What
* Replace \[\]\(\) on \[\]\[\]
* Change releases badge link
* Re-render readme

### Why
* \[\]\(\) style doesn't support variables. [Docs](https://github.com/hugo-2013-07-29/hugo-2013-07-29/blob/master/src/github.com/theplant/blackfriday/upskirtref/Markdown%20Documentation%20-%20Syntax.text#L548)
* Badge has wrong url
* Old template has a bug so avatars links were broken