### PR TITLE
[modules/go] re-write go vet target

### DIFF
--- a/modules/go/Makefile.style
+++ b/modules/go/Makefile.style
@@ -6,7 +6,7 @@ go/lint: $(GO) go/vet
 ## Vet code
 go/vet: $(GO)
 	$(call assert-set,GO)
-	$(GO) tool vet -v $(CURDIR)
+	find . ! -path "*/vendor/*" ! -path "*/.glide/*" -type f -name '*.go' | xargs $(GO) tool vet -v
 
 ## Format code according to Golang convention
 go/fmt: $(GO)

--- a/modules/go/Makefile.style
+++ b/modules/go/Makefile.style
@@ -6,7 +6,7 @@ go/lint: $(GO) go/vet
 ## Vet code
 go/vet: $(GO)
 	$(call assert-set,GO)
-	find . ! -path "*/vendor/*" ! -path "*/.glide/*" -type f -name '*.go' | xargs $(GO) vet -v
+	$(GO) tool vet -v $(CURDIR)
 
 ## Format code according to Golang convention
 go/fmt: $(GO)


### PR DESCRIPTION
## what
use `go too vet $dir` to vet code

## why
`go vet` command require:
> named files must all be in one directory; have ...

Should fix https://github.com/cloudposse/github-authorized-keys/issues/29