### PR TITLE
[helm.toolbox.upsert]: tiller rbac support

### DIFF
--- a/bin/helm_toolbox.sh
+++ b/bin/helm_toolbox.sh
@@ -45,16 +45,20 @@ function upsert() {
     if [ "$helm_version" != "$tiller_version" ]; then
         info "Helm version: $helm_version, differs with tiller version: ${tiller_version:-'not installed'}"
         info "Upgrarding tiller to $helm_version"        
-        local tiller_serviceaccount=tiller
-        local tiller_serviceaccount_exists=$(kubectl get serviceaccount -n kube-system --ignore-not-found=true --request-timeout=${TIMEOUT}s -o name $tiller_serviceaccount 2> /dev/null)
-        local tiller_clusterrolebinding_exists=$(kubectl get clusterrolebinding --ignore-not-found=true --request-timeout=${TIMEOUT}s -o name tiller-cluster-rule 2> /dev/null)
-        if [ -z "$tiller_serviceaccount_exists" ]; then
-            kubectl create serviceaccount --namespace kube-system $tiller_serviceaccount > $STDOUT
+        if [ $RBAC_ENABLED ]; then
+            local tiller_serviceaccount=tiller
+            local tiller_serviceaccount_exists=$(kubectl get serviceaccount -n kube-system --ignore-not-found=true --request-timeout=${TIMEOUT}s -o name $tiller_serviceaccount 2> /dev/null)
+            local tiller_clusterrolebinding_exists=$(kubectl get clusterrolebinding --ignore-not-found=true --request-timeout=${TIMEOUT}s -o name tiller-cluster-rule 2> /dev/null)
+            if [ -z "$tiller_serviceaccount_exists" ]; then
+                kubectl create serviceaccount --namespace kube-system $tiller_serviceaccount > $STDOUT
+            fi
+            if [ -z $tiller_clusterrolebinding_exists ]; then
+                kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:$tiller_serviceaccount > $STDOUT
+            fi
+            helm init --service-account $tiller_serviceaccount --upgrade --force-upgrade --wait > $STDOUT
+        else
+            helm init --upgrade --force-upgrade --wait > $STDOUT
         fi
-        if [ -z $tiller_clusterrolebinding_exists ]; then
-            kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:$tiller_serviceaccount > $STDOUT
-        fi
-        helm init --service-account $tiller_serviceaccount --upgrade --force-upgrade --wait > $STDOUT
         info "Helm version"
         helm version --short | sed 's/^/  - /'
     else

--- a/bin/helm_toolbox.sh
+++ b/bin/helm_toolbox.sh
@@ -49,10 +49,10 @@ function upsert() {
         local tiller_serviceaccount_exists=$(kubectl get serviceaccount -n kube-system --ignore-not-found=true --request-timeout=${TIMEOUT}s -o name $tiller_serviceaccount 2> /dev/null)
         local tiller_clusterrolebinding_exists=$(kubectl get clusterrolebinding --ignore-not-found=true --request-timeout=${TIMEOUT}s -o name tiller-cluster-rule 2> /dev/null)
         if [ -z "$tiller_serviceaccount_exists" ]; then
-      	    kubectl create serviceaccount --namespace kube-system $tiller_serviceaccount > $STDOUT
+            kubectl create serviceaccount --namespace kube-system $tiller_serviceaccount > $STDOUT
         fi
         if [ -z $tiller_clusterrolebinding_exists ]; then
-        	kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:$tiller_serviceaccount > $STDOUT
+            kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:$tiller_serviceaccount > $STDOUT
         fi
         helm init --service-account $tiller_serviceaccount --upgrade --force-upgrade --wait > $STDOUT
         info "Helm version"

--- a/bin/helm_toolbox.sh
+++ b/bin/helm_toolbox.sh
@@ -44,8 +44,17 @@ function upsert() {
     local tiller_version=$(helm version --server --short --tiller-connection-timeout $TIMEOUT 2> /dev/null | grep -Eo "v[0-9]+\.[0-9]+\..+")
     if [ "$helm_version" != "$tiller_version" ]; then
         info "Helm version: $helm_version, differs with tiller version: ${tiller_version:-'not installed'}"
-        info "Upgrarding tiller to $helm_version"
-        helm init --upgrade --force-upgrade --wait > $STDOUT
+        info "Upgrarding tiller to $helm_version"        
+        local tiller_serviceaccount=tiller
+        local tiller_serviceaccount_exists=$(kubectl get serviceaccount -n kube-system --ignore-not-found=true --request-timeout=${TIMEOUT}s -o name $tiller_serviceaccount 2> /dev/null)
+        local tiller_clusterrolebinding_exists=$(kubectl get clusterrolebinding --ignore-not-found=true --request-timeout=${TIMEOUT}s -o name tiller-cluster-rule 2> /dev/null)
+        if [ -z "$tiller_serviceaccount_exists" ]; then
+      	    kubectl create serviceaccount --namespace kube-system $tiller_serviceaccount > $STDOUT
+        fi
+        if [ -z $tiller_clusterrolebinding_exists ]; then
+        	kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:$tiller_serviceaccount > $STDOUT
+        fi
+        helm init --service-account $tiller_serviceaccount --upgrade --force-upgrade --wait > $STDOUT
         info "Helm version"
         helm version --short | sed 's/^/  - /'
     else


### PR DESCRIPTION
## what
* create service-account and clusterrolebinding for helm tiller (if not exists)
* pass service-account to helm init

## why
to support RBAC on helm level
