### PR TITLE
[github] Add target to return the latest release from API

### DIFF
--- a/bin/github_repo_metadata.sh
+++ b/bin/github_repo_metadata.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+function fetch() {
+  local org=$1
+  local repo=$2
+  local api=$3
+  local path=$4
+  local header=""
+
+  if [ -n "$GITHUB_TOKEN" ] ; then
+    header="Authorization: token $GITHUB_TOKEN"
+  fi
+
+  if [ "${api}" == "index" ]; then
+    api=""
+  else
+    api="/${api}"
+  fi
+
+  local ref=$(curl -sSL -H "$header" "https://api.github.com/repos/$org/${repo}${api}" | jq -r "$path")
+  if [ $? -eq 0 ]; then
+    echo $ref
+  fi
+}
+
+if [ $# -eq 4 ]; then
+  fetch "${1}" "${2}" "${3}" "${4}"
+else
+  echo "Usage: $0 [org] [repo] [api] [jq path]"
+  echo "  e.g. $0 cloudposse geodesic license .license.spdx_id"
+  echo "       $0 cloudposse geodesic releases/latest .tag_name"
+  echo "       $0 cloudposse geodesic '' .description"
+  exit 1
+fi
+

--- a/modules/git/bootstrap.Makefile
+++ b/modules/git/bootstrap.Makefile
@@ -27,4 +27,7 @@ else
   export GIT_IS_BRANCH := 1
 endif
 
+export GIT_REPO ?= $(shell basename $$(git remote get-url origin) .git)
+export GIT_ORG ?= $(shell dirname $$(git remote get-url origin) | cut -d: -f2)
+
 endif

--- a/modules/github/Makefile.release
+++ b/modules/github/Makefile.release
@@ -27,3 +27,9 @@ github/push-artifacts: packages/install/ghr-linux
 	$(call assert-set,GIT_TAG)
 	$(call assert-set,ARTIFACTS)
 	@ghr $(GIT_TAG) $(ARTIFACTS)
+
+.PHONY : github/latest-release
+## Fetch the latest release tag from the GitHub API
+github/latest-release:
+	@$(BUILD_HARNESS_PATH)/bin/github_repo_metadata.sh '$(GIT_ORG)' '$(GIT_REPO)' 'releases/latest' '.tag_name'
+


### PR DESCRIPTION
## what
* Add `github/latest-release` target to emit the latest release from the API

## why
* There's no way to accurately derive the latest release via tags. Sorting is not always correct. Latest is what has been deemed latest using the releases UI.

## demo
Here's the output running it in `build-harness`
```
make github/latest-release
0.12.5
```

