### PR TITLE
Fix GIT_ORG Env

### DIFF
--- a/modules/git/bootstrap.Makefile
+++ b/modules/git/bootstrap.Makefile
@@ -36,7 +36,8 @@ else
   export GIT_IS_BRANCH := 1
 endif
 
-export GIT_REPO ?= $(shell basename $$(git remote get-url origin) .git)
-export GIT_ORG ?= $(shell dirname $$(git remote get-url origin) | cut -d: -f2)
+export GIT_URL ?= $(shell git remote get-url origin)
+export GIT_REPO ?= $(shell basename $(GIT_URL) .git)
+export GIT_ORG ?= $(shell basename $$(dirname $(GIT_URL) | cut -d: -f2))
 
 endif


### PR DESCRIPTION
## what
* Fix `GIT_ORG` extraction from ssh and https origins

## why
* Previously, only `ssh` based git urls were supported
* Codefresh uses https git urls
