### PR TITLE
Remove default value for DEBUG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ export SELF ?= $(MAKE)
 export PATH := $(BUILD_HARNESS_PATH)/vendor:$(PATH)
 export DOCKER_BUILD_FLAGS ?=
 
+# Debug should not be defaulted to a value because some cli consider any value as `true` (e.g. helm)
+export DEBUG ?=
+
 ifeq ($(CURDIR),$(realpath $(BUILD_HARNESS_PATH)))
 # List of targets the `readme` target should call before generating the readme
 export README_DEPS ?= docs/targets.md

--- a/modules/git/bootstrap.Makefile
+++ b/modules/git/bootstrap.Makefile
@@ -1,5 +1,3 @@
-export DEBUG ?= false
-
 ifeq ($(wildcard .git),)
   ifeq ($(DEBUG),true)
     $(warning disabling git bootstrapping)

--- a/modules/helm/Makefile.repo
+++ b/modules/helm/Makefile.repo
@@ -1,6 +1,5 @@
 HELM_REPO_NAMES ?= stable incubator demo
 HELM_REPO_PREFIX ?= cloudposse
-export DEBUG ?= false
 
 REPO_URL?=https://charts.cloudposse.com
 

--- a/modules/semver/Makefile
+++ b/modules/semver/Makefile
@@ -1,5 +1,3 @@
-export DEBUG ?= false
-
 ifneq ($(wildcard .git),)
 ## Array of all possible versions based on this git commit
 SEMVERSIONS :=

--- a/modules/travis/Makefile
+++ b/modules/travis/Makefile
@@ -1,5 +1,3 @@
-export DEBUG ?= false
-
 # Generate the canonical tag
 ifneq ($(TRAVIS_PULL_REQUEST_BRANCH),)
   CANONICAL_TAG ?= pr-$(TRAVIS_PULL_REQUEST_BRANCH)-$(TRAVIS_BUILD_NUMBER)


### PR DESCRIPTION
## what
* Do not initialize default variables in multiple makefiles (confusing)
* `DEBUG` is a non-namespaced env that is used by multiple apps; cannot default the value

## why
* `helm` only looks to see if `DEBUG` is set (and not the value) to enable debug mode
