### PR TITLE
Silence help/short target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ include $(BUILD_HARNESS_PATH)/modules/*/Makefile*
 
 ifndef TRANSLATE_COLON_NOTATION
 %:
-	@$(SELF) $(subst :,/,$@) TRANSLATE_COLON_NOTATION=false
+	@$(SELF) -s $(subst :,/,$@) TRANSLATE_COLON_NOTATION=false
 endif

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -40,7 +40,7 @@ help/all:
 ## This help short screen
 help/short:
 	@printf "Available targets:\n\n"
-	@$(SELF) help/generate MAKEFILE_LIST="Makefile $(BUILD_HARNESS_PATH)/Makefile.helpers"
+	@$(SELF) -s help/generate MAKEFILE_LIST="Makefile $(BUILD_HARNESS_PATH)/Makefile.helpers"
 
 # Generate help output from MAKEFILE_LIST
 help/generate:


### PR DESCRIPTION
## what
* Silence `help/short` target using `-s` flag to make

## why
* Output was ugly
```
Available targets:

make[1]: Entering directory `/home/erik.osterman/Dev/cloudposse/reference-architectures'
  clean                               Clean up 
  help                                Help screen
  help/all                            Display help for all targets
  help/short                          This help short screen

make[1]: Leaving directory `/home/erik.osterman/Dev/cloudposse/reference-architectures'
```