### PR TITLE
codefresh module fix, repo creation added, package version bumped

### DIFF
--- a/modules/codefresh/Makefile.sync
+++ b/modules/codefresh/Makefile.sync
@@ -1,7 +1,7 @@
 export CODEFRESH_CLI ?= codefresh
 export CODEFRESH_CLI_SHARED_DIR ?= /data
 
-export PIPELINES ?= $(call pipelines,$(ACCOUNT))
+PIPELINES ?= $(call pipelines,$(ACCOUNT))
 
 define pipelines
 	$(value $(shell echo $(1)_PIPELINES | tr 'a-z' 'A-Z'))

--- a/modules/packages/Makefile
+++ b/modules/packages/Makefile
@@ -1,5 +1,5 @@
 export INSTALL_PATH ?= $(BUILD_HARNESS_PATH)/vendor
-export PACKAGES_VERSION ?= 0.53.0
+export PACKAGES_VERSION ?= 0.68.0
 export PACKAGES_PATH ?= $(BUILD_HARNESS_PATH)/vendor/packages
 
 ## Delete packages


### PR DESCRIPTION
## What
* fix for codefresh module. there is a recursion call to same makefile, and having variable being exported broke the logic
* Codefresh repo creation added (if not exists)
* package version bumped (to the one with recent codefresh-cli)

## Why
* all this are required for `cloudposse/codefresh` repo functionality