### PR TITLE
Export Environment Variables for Codefresh Docker Tags

### DIFF
--- a/modules/codefresh/Makefile
+++ b/modules/codefresh/Makefile
@@ -12,7 +12,12 @@ codefresh/trigger/webhook:
 	 --data-binary \
 		'{"serviceId":"$(CF_TRIGGER_SERVICE_ID)","type":"$(CF_TRIGGER_TYPE)","repoOwner":"$(CF_TRIGGER_REPO_OWNER)","branch":"$(CF_TRIGGER_BRANCH)","repoName":"$(CF_TRIGGER_REPO_NAME)"}'
 
-## DEPRECATED!!! Export codefresh additional envvars
+## Export codefresh additional envvars
 codefresh/export:
 	$(call assert-set,CF_BUILD_TIMESTAMP)
 	@echo "CF_BUILD_UNIX_TIMESTAMP=$(shell expr $(CF_BUILD_TIMESTAMP) / 1000)"
+	@echo "IS_CODEFRESH=$(IS_CODEFRESH)"
+	@echo "CICD_BUILD_ID=$(CICD_BUILD_ID)"
+	@echo "CICD_COMMIT=$(CICD_COMMIT)"
+	@echo "CICD_DOCKER_IMAGE_PULL_REQUEST_TAG=$(CICD_DOCKER_IMAGE_PULL_REQUEST_TAG)"
+	@echo "CICD_DOCKER_IMAGE_LATEST_TAG=$(CICD_DOCKER_IMAGE_LATEST_TAG)"

--- a/modules/codefresh/bootstrap.Makefile
+++ b/modules/codefresh/bootstrap.Makefile
@@ -1,0 +1,25 @@
+LATEST_TAG_STRING = "latest"
+
+ifeq ($(CF_BUILD_ID),)
+## this is not a Codefresh build context
+	export IS_CODEFRESH := 0
+else
+	export IS_CODEFRESH := 1
+## common build ID we can use with different CI/CD systems
+  export CICD_BUILD_ID := "$(CF_BUILD_ID)"
+  export CICD_COMMIT := "$(CF_REVISION)"
+
+  ifneq ($(CF_PULL_REQUEST_ID),)
+    export CICD_DOCKER_IMAGE_PULL_REQUEST_TAG := "pr-$(CF_BRANCH_TAG_NORMALIZED)-$(CF_BUILD_ID)"
+
+    ifeq ($(CF_PULL_REQUEST_ACTION),closed)
+      export CICD_DOCKER_IMAGE_LATEST_TAG := $(LATEST_TAG_STRING)
+    endif
+
+  endif
+
+  ifeq ($(CF_BRANCH),master)
+    export CICD_DOCKER_IMAGE_LATEST_TAG := $(LATEST_TAG_STRING)
+  endif
+
+endif


### PR DESCRIPTION
## What
* exporting some new variables to use as `Docker` tags for `Codefresh` push step. going to use instead `travis_docker_tag_and_push.sh`

## Why
* Because of migrating to `Codefresh`. Now we can use all new variables as `Docker` tags in a single push step, without conditions (by branch, PR, release etc). So only proper variables will be defined.