### PR TITLE
Remove opsgoodness from helm chart dependencies

### DIFF
--- a/modules/docker/Makefile.build
+++ b/modules/docker/Makefile.build
@@ -2,6 +2,7 @@
 ## User ARGS to pass arguments
 DOCKER_BUILD_PATH ?= .
 DOCKER_BUILD_FLAGS ?= --no-cache
+DOCKER_IMAGE_NAME ?= tests
 DOCKER_FILE ?= ./Dockerfile
 
 ## Build docker image

--- a/modules/helm/Makefile.repo
+++ b/modules/helm/Makefile.repo
@@ -41,9 +41,6 @@ helm/repo/add-all:
 	@REPO_NAME=kubernetes-charts \
 		REPO_ENDPOINT=http://storage.googleapis.com/kubernetes-charts \
 		$(SELF) -s --no-print-directory helm/repo/add
-	@REPO_NAME=opsgoodness \
-		REPO_ENDPOINT=http://charts.opsgoodness.com \
-		$(SELF) -s --no-print-directory helm/repo/add
 	@REPO_NAME=kubernetes-charts-incubator \
 		REPO_ENDPOINT=https://kubernetes-charts-incubator.storage.googleapis.com \
 		$(SELF) -s --no-print-directory helm/repo/add


### PR DESCRIPTION
## What it is
- Removes `opsgoodness` from `helm/repo/add-all`

## Why
- This is not being used anywhere