### PR TITLE
[codefresh-sync] Leave TMP_DIR around for future use

### DIFF
--- a/bin/codefresh-sync.sh
+++ b/bin/codefresh-sync.sh
@@ -111,3 +111,5 @@ fi
 
 ## Cleanup tmp directory
 rm -rf ${TMP_DIR}
+## Make sure tmp directory exists for future builds
+mkdir -p ${TMP_DIR}


### PR DESCRIPTION
## what
Make Codefresh re-create $TMP_DIR after deleting it

## why
Future builds may need it.  