### PR TITLE
Update packages

### DIFF
--- a/modules/helm/Makefile
+++ b/modules/helm/Makefile
@@ -1,5 +1,4 @@
 CURL ?= curl
-export HELM_VERSION ?= 2.11.0
 HELM_PLATFORM ?= $(OS)-amd64
 HELM ?= helm
 HELM_HOME ?= $(HOME)/.helm

--- a/modules/packages/Makefile
+++ b/modules/packages/Makefile
@@ -1,5 +1,5 @@
 export INSTALL_PATH ?= $(BUILD_HARNESS_PATH)/vendor
-export PACKAGES_VERSION ?= 0.68.0
+export PACKAGES_VERSION ?= 0.84.0
 export PACKAGES_PATH ?= $(BUILD_HARNESS_PATH)/vendor/packages
 
 ## Delete packages


### PR DESCRIPTION
## what
* Drop `HELM_VERSION` pinning and instead use pinning in `packages`

## why
* This caused problems with `cloudposse/packages`, since the build-harness defines a version that overrides the version in `cloudposse/packages`