### PR TITLE
Add a note about pinning module dependencies

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017-2018 Cloud Posse, LLC
+   Copyright 2017-2019 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -44,13 +44,13 @@ Available targets:
   geodesic/deploy                     Run a Jenkins Job to Deploy $(APP) with $(CANONICAL_TAG)
   git/aliases-update                  Update git aliases
   git/export                          Export git vars
+  git/submodules-update               Update submodules
   github/download-private-release     Download release from github
   github/download-public-release      Download release from github
   github/latest-release               Fetch the latest release tag from the GitHub API
   github/push-artifacts               Push all release artifacts to GitHub (Required: `GITHUB_TOKEN`)
   gitleaks/install                    Install gitleaks
   gitleaks/scan                       Scan current repository
-  git/submodules-update               Update submodules
   go/build                            Build binary
   go/build-all                        Build binary for all platforms
   go/clean                            Clean compiled binary
@@ -79,7 +79,6 @@ Available targets:
   helm/delete/failed                  Delete all failed releases in a `NAMESPACE` subject to `FILTER`
   helm/delete/namespace               Delete all releases in a `NAMEPSACE` as well as the namespace
   helm/delete/namespace/empty         Delete `NAMESPACE` if there are no releases in it
-  helmfile/install                    Install helmfile
   helm/install                        Install helm
   helm/repo/add                       Add $REPO_NAME from $REPO_ENDPOINT
   helm/repo/add-current               Add helm remote dev repos
@@ -92,16 +91,17 @@ Available targets:
   helm/repo/update                    Update repo info
   helm/serve/index                    Build index for serve helm charts
   helm/toolbox/upsert                 Install or upgrade helm tiller 
+  helmfile/install                    Install helmfile
   help                                Help screen
   help/all                            Display help for all targets
   help/short                          This help short screen
   jenkins/run-job-with-tag            Run a Jenkins Job with $(TAG)
   make/lint                           Lint all makefiles
   packages/delete                     Delete packages
-  packages/install/%                  Install package (e.g. helm, helmfile, kubectl)
   packages/install                    Install packages 
-  packages/reinstall/%                Reinstall package (e.g. helm, helmfile, kubectl)
+  packages/install/%                  Install package (e.g. helm, helmfile, kubectl)
   packages/reinstall                  Reinstall packages
+  packages/reinstall/%                Reinstall package (e.g. helm, helmfile, kubectl)
   packages/uninstall/%                Uninstall package (e.g. helm, helmfile, kubectl)
   readme                              Alias for readme/build
   readme/build                        Create README.md by building it from README.yaml

--- a/templates/README.md
+++ b/templates/README.md
@@ -67,11 +67,13 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 {{ if has (ds "config") "usage" }}
 ## Usage
 
+{{ if (file.Exists "main.tf") }}
 **IMPORTANT:** The example shows pinning to the `master` branch. 
 This is a reminder that you need to pin your dependencies for reproducibility and visibility.
 Explicit versioning allows knowing exactly which version of each dependency is used at any time.
 However, in your code do not pin to `master` because there may be breaking changes between releases.
 Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/{{(ds "config").name}}/releases).
+{{end}}
 
 {{ (ds "config").usage -}}
 {{ end }}

--- a/templates/README.md
+++ b/templates/README.md
@@ -69,7 +69,7 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 {{ if (file.Exists "main.tf") }}
 **IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
-Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/{{(ds "config").name}}/releases).
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases]({{ printf "https://github.com/%s/releases" (ds "config").github_repo}}).
 {{end}}
 
 {{ (ds "config").usage -}}

--- a/templates/README.md
+++ b/templates/README.md
@@ -67,6 +67,12 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 {{ if has (ds "config") "usage" }}
 ## Usage
 
+**IMPORTANT:** The example shows pinning to the `master` branch. 
+This is a reminder that you need to pin your dependencies for reproducibility and visibility.
+Explicit versioning allows knowing exactly which version of each dependency is used at any time.
+However, in your code do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/{{(ds "config").name}}/releases).
+
 {{ (ds "config").usage -}}
 {{ end }}
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -68,10 +68,7 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 ## Usage
 
 {{ if (file.Exists "main.tf") }}
-**IMPORTANT:** The example shows pinning to the `master` branch. 
-This is a reminder that you need to pin your dependencies for reproducibility and visibility.
-Explicit versioning allows knowing exactly which version of each dependency is used at any time.
-However, in your code do not pin to `master` because there may be breaking changes between releases.
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
 Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/{{(ds "config").name}}/releases).
 {{end}}
 


### PR DESCRIPTION
## what
* Add a note about pinning module dependencies

## why
* Users should always do module version pinning for reproducibility and visibility
* Users should pin to a release and not use the `master` branch because there could be breaking changes between releases
* Some users either forget to pin at all, or pin to `master` in production code
* Just a friendly reminder
* Will be included in every terraform module README


 
 