### PR TITLE
0.12 support for terraform-docs

### DIFF
--- a/bin/terraform-docs.awk
+++ b/bin/terraform-docs.awk
@@ -1,0 +1,45 @@
+# This script converts Terraform 0.12 variables/outputs to something suitable for `terraform-docs`
+# As of terraform-docs v0.6.0, HCL2 is not supported. This script is a *dirty hack* to get around it.
+# https://github.com/segmentio/terraform-docs/
+# https://github.com/segmentio/terraform-docs/issues/62
+
+{
+  if ( /{/ ) { 
+    braceCnt++ 
+  }
+
+  if ( /}/ ) { 
+    braceCnt-- 
+  }
+
+  if ($0 ~ /(variable|output) "(.*?)"/) {
+    blockCnt++
+    print $0
+  }
+
+  if ($1 == "description") {
+    print $0
+  }
+
+  if ($1 == "default") {
+    if (braceCnt > 1) {
+      print "  default = {}"
+    } else {
+      print $0
+    }
+  }
+
+  if ($1 == "type" ) {
+    type=$3
+    if (type ~ "object") {
+      print "  type = \"object\""
+    } else {
+      print "  type = \"" $3 "\"" 
+    }
+  }
+
+  if (braceCnt == 0 && blockCnt > 0) {
+    blockCnt--
+    print $0
+  }
+}

--- a/bin/terraform-docs.awk
+++ b/bin/terraform-docs.awk
@@ -4,11 +4,11 @@
 # https://github.com/segmentio/terraform-docs/issues/62
 
 {
-  if ( /{/ ) { 
+  if ( /\{/ ) { 
     braceCnt++ 
   }
 
-  if ( /}/ ) { 
+  if ( /\}/ ) { 
     braceCnt-- 
   }
 

--- a/bin/terraform-docs.sh
+++ b/bin/terraform-docs.sh
@@ -4,7 +4,7 @@ which awk 2>&1 >/dev/null || ( echo "awk not available"; exit 1)
 which terraform 2>&1 >/dev/null || ( echo "terraform not available"; exit 1)
 which terraform-docs 2>&1 >/dev/null || ( echo "terraform-docs not available"; exit 1)
 
-if [[ "`terraform version`" =~ 0\.12 ]]; then
+if [[ "`terraform version | head -1`" =~ 0\.12 ]]; then
     TMP_FILE="$(mktemp /tmp/terraform-docs-XXXXXXXXXX.tf)"
     awk -f ${BUILD_HARNESS_PATH}/bin/terraform-docs.awk $2/*.tf > ${TMP_FILE}
     terraform-docs $1 ${TMP_FILE}

--- a/bin/terraform-docs.sh
+++ b/bin/terraform-docs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+which awk 2>&1 >/dev/null || ( echo "awk not available"; exit 1)
+which terraform 2>&1 >/dev/null || ( echo "terraform not available"; exit 1)
+which terraform-docs 2>&1 >/dev/null || ( echo "terraform-docs not available"; exit 1)
+
+if [[ "`terraform version`" =~ 0\.12 ]]; then
+    TMP_FILE="$(mktemp /tmp/terraform-docs-XXXXXXXXXX.tf)"
+    awk -f ${BUILD_HARNESS_PATH}/bin/terraform-docs.awk $2/*.tf > ${TMP_FILE}
+    terraform-docs $1 ${TMP_FILE}
+    rm -f ${TMP_FILE}
+else
+    terraform-docs $1 $2
+fi

--- a/modules/docs/Makefile
+++ b/modules/docs/Makefile
@@ -15,4 +15,4 @@ docs/targets.md: docs/deps
 .PHONY : docs/terraform.md
 ## Update `docs/terraform.md` from `terraform-docs`
 docs/terraform.md: docs/deps packages/install/terraform-docs
-	@terraform-docs md . > $@
+	@$(BUILD_HARNESS_PATH)/bin/terraform-docs.sh md . > $@


### PR DESCRIPTION
## what
* Add a hack to support terraform `0.12` with `terraform-docs`
* Use `awk` to generate variables and outputs suitable for `terraform-docs`

## why
* `terraform-docs` does not yet support HCL2

## references
* https://github.com/segmentio/terraform-docs/issues/62