### PR TITLE
#152 Ensure terraform-docs 0.12 multi-line default statement is parsed correctly

### DIFF
--- a/bin/terraform-docs.awk
+++ b/bin/terraform-docs.awk
@@ -8,7 +8,7 @@
     braceCnt++
   }
 
-   if ( /\}/ ) {
+  if ( /\}/ ) {
     braceCnt--
   }
 

--- a/bin/terraform-docs.awk
+++ b/bin/terraform-docs.awk
@@ -4,42 +4,76 @@
 # https://github.com/segmentio/terraform-docs/issues/62
 
 {
-  if ( /\{/ ) { 
-    braceCnt++ 
+  if ( /\{/ ) {
+    braceCnt++
   }
 
-  if ( /\}/ ) { 
-    braceCnt-- 
+   if ( /\}/ ) {
+    braceCnt--
   }
 
+  # [START] variable or output block started
   if ($0 ~ /(variable|output) "(.*?)"/) {
+    # [CLOSE] "default" block
+    if (blockDefCnt > 0) {
+      blockDefCnt = 0
+    }
     blockCnt++
     print $0
   }
 
-  if ($1 == "description") {
-    print $0
+  # [START] multiline default statement started
+  if (blockCnt > 0) {
+    if ($1 == "default") {
+      print $0
+      if ($NF ~ /[\[\(\{]/) {
+        blockDefCnt++
+        blockDefStart=1
+      }
+    }
   }
 
-  if ($1 == "default") {
-    if (braceCnt > 1) {
-      print "  default = {}"
-    } else {
+  # [PRINT] single line "description"
+  if (blockDefCnt == 0) {
+    if ($1 == "description") {
+      # [CLOSE] "default" block
+      if (blockDefCnt > 0) {
+        blockDefCnt = 0
+      }
       print $0
     }
   }
 
-  if ($1 == "type" ) {
-    type=$3
-    if (type ~ "object") {
-      print "  type = \"object\""
-    } else {
-      print "  type = \"" $3 "\"" 
+  # [PRINT] single line "type"
+  if (blockCnt > 0) {
+    if ($1 == "type" ) {
+      # [CLOSE] "default" block
+      if (blockDefCnt > 0) {
+        blockDefCnt = 0
+      }
+      type=$3
+      if (type ~ "object") {
+        print "  type = \"object\""
+      } else {
+        print "  type = \"" $3 "\""
+      }
     }
   }
 
-  if (braceCnt == 0 && blockCnt > 0) {
-    blockCnt--
-    print $0
+  # [CLOSE] variable/output block
+  if (blockCnt > 0) {
+    if (braceCnt == 0 && blockCnt > 0) {
+      blockCnt--
+      print $0
+    }
+  }
+
+  # [PRINT] Multiline "default" statement
+  if (blockCnt > 0 && blockDefCnt > 0) {
+    if (blockDefStart == 1) {
+      blockDefStart = 0
+    } else {
+      print $0
+    }
   }
 }


### PR DESCRIPTION
# terraform-docs 0.12 multi-line default parsing

## Description

There currently seems to be an issue with multi-line default statement parsing as mentioned by @antonbabenko here: https://github.com/cloudposse/build-harness/pull/152#issuecomment-499389406

This PR tries to address this.

## Note

I've tested this on various samples to the best of my knowledge, but there may be other edge cases that I haven't yet taken into consideration.

## Samples


### Sample CI build
For a complex sample, I've re-triggered our CI pipeline, which is now using the here provided awk script, building terraform-docs output for one Terraform 0.12 main module and 4 bundled example usages. There seem to be no issues so far: https://travis-ci.com/Flaconi/terraform-aws-microservice/builds/115597635#L500

### Sample file
`input:`
```hcl
variable "database_outbound_acl_rules" {
  description = "Database subnets outbound network ACL rules"
  type        = list(map(string))
  default     = [
    {
      rule_number = 100
      rule_action = "allow"
      from_port   = 0
      to_port     = 0
      protocol    = "-1"
      cidr_block  = "0.0.0.0/0"
    },
  ]
}

variable "network" {
  description = "The network"
  type        = object({
    vpc = object({
      id         = string
      cidr_block = string
    })
    subnets = set(object({
      id         = string
      cidr_block = string
    }))
  })
  default     = {
    vpc = {
      id          = "vpc-123456"
      cidr_block  = "10.0.0.0/16"
    },
    subnets = [
      {
        id          = "vpc-123456"
        cidr_block  = "10.0.0.0/16"
      },
    ],
  }
}

output "environment" {
  description = "The output"
  value       = {
    id = aws_elastic_beanstalk_environment.example.id
    vpc_settings = {
      for s in aws_elastic_beanstalk_environment.example.all_settings :
      s.name => s.value
      if s.namespace == "aws:ec2:vpc"
    }
  }
}
```
`output:`
```hcl
variable "database_outbound_acl_rules" {
  description = "Database subnets outbound network ACL rules"
  type = "list(map(string))"
  default     = [
    {
      rule_number = 100
      rule_action = "allow"
      from_port   = 0
      to_port     = 0
      protocol    = "-1"
      cidr_block  = "0.0.0.0/0"
    },
  ]
}
variable "network" {
  description = "The network"
  type = "object"
  default     = {
    vpc = {
      id          = "vpc-123456"
      cidr_block  = "10.0.0.0/16"
    },
    subnets = [
      {
        id          = "vpc-123456"
        cidr_block  = "10.0.0.0/16"
      },
    ],
  }
}
output "environment" {
  description = "The output"
}
```
`terraform-docs`
```
## Inputs

| Name | Description | Type | Default | Required |
|------|-------------|:----:|:-----:|:-----:|
| database\_outbound\_acl\_rules | Database subnets outbound network ACL rules | list(map(string)) | `[ { "cidr_block": "0.0.0.0/0", "from_port": 0, "protocol": "-1", "rule_action": "allow", "rule_number": 100, "to_port": 0 } ]` | no |
| network | The network | object | `{ "subnets": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ], "vpc": [ { "cidr_block": "10.0.0.0/16", "id": "vpc-123456" } ] }` | no |

## Outputs

| Name | Description |
|------|-------------|
| environment | The output |
```