### PR TITLE
Fix: Do not double quote TF >= 0.12 legacy quoted types

### DIFF
--- a/bin/terraform-docs.awk
+++ b/bin/terraform-docs.awk
@@ -61,7 +61,12 @@
       if (type ~ "object") {
         print "  type = \"object\""
       } else {
-        print "  type = \"" $3 "\""
+          # legacy quoted types: "string", "list", and "map"
+          if ($3 ~ /^[[:space:]]*"(.*?)"[[:space:]]*$/) {
+            print "  type = " $3
+          } else {
+            print "  type = \"" $3 "\""
+          }
       }
     }
   }


### PR DESCRIPTION
## Do not double quote TF >= 0.12 legacy quoted types

This PR addresses another issue with double-double quoting legacy types. This happens if you still double quote `string`, `list` and `map` in Terraform >= 0.12.

```
Error: Invalid legacy variable type hint

  on variables.tf line 2, in variable "test":
   2:   type        = "map(string)"

The legacy variable type hint form, using a quoted string, allows only the
values "string", "list", and "map". To provide a full type expression, remove
the surrounding quotes and give the type expression directly.
```

You can find the reporting here: https://github.com/antonbabenko/pre-commit-terraform/issues/52#issuecomment-505228034

As well as the initial fix including regression tests here: https://github.com/cytopia/docker-terraform-docs/pull/16

An example to reproduce the faulty behaviour (before this PR might be merged) can be found here:
https://github.com/cytopia/docker-terraform-docs/blob/master/tests/0.12/main.tf#L60