### PR TITLE
Generate unique temporary file for terraform-docs generation

### DIFF
--- a/bin/terraform-docs.sh
+++ b/bin/terraform-docs.sh
@@ -5,7 +5,7 @@ which terraform 2>&1 >/dev/null || ( echo "terraform not available"; exit 1)
 which terraform-docs 2>&1 >/dev/null || ( echo "terraform-docs not available"; exit 1)
 
 if [[ "`terraform version | head -1`" =~ 0\.12 ]]; then
-    TMP_FILE="$(mktemp /tmp/terraform-docs-XXXXXXXXXX.tf)"
+    TMP_FILE="$(mktemp /tmp/terraform-docs-XXXXXXXXXX)"
     awk -f ${BUILD_HARNESS_PATH}/bin/terraform-docs.awk $2/*.tf > ${TMP_FILE}
     terraform-docs $1 ${TMP_FILE}
     rm -f ${TMP_FILE}


### PR DESCRIPTION
## what
*  removing .tf from the template it always will use a unique file

## why
The script to generate terraform docs uses an intermediate to pre process files with awk as work around of a limitation in the terraform-docs tool for terraform version 0.12. The temporary file created is not a unique file, it always generate the following file. /tmp/terraform-docs-XXXXXXXXXX.tf In case the generate file is not cleared or in recursive usages mode the script fails frequent. See also #159 

```
➜  ~ TMP_FILE="$(mktemp /tmp/terraform-docs.XXXXXXXXXX.tf)" && echo $TMP_FILE
mktemp: mkstemp failed on /tmp/terraform-docs.XXXXXXXXXX.tf: File exists
➜  ~ TMP_FILE="$(mktemp /tmp/terraform-docs.XXXXXXXXXX)" && echo $TMP_FILE
/tmp/terraform-docs.UWcXrdbU7D
```

## why
* closes #159 