### PR TITLE
Support validation for 0.12

### DIFF
--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -25,8 +25,10 @@ terraform/get-modules:
 ## Basic terraform sanity check
 terraform/validate:
 ifeq ("12","$(word 2, $(subst ., ,$(TERRAFORM_VERSION)))")
+	echo $(TERRAFORM_VERSION)
 	@$(TERRAFORM) validate;
 else
+	echo $(TERRAFORM_VERSION)
 	@$(TERRAFORM) validate -check-variables=false
 endif
 

--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -25,10 +25,9 @@ terraform/get-modules:
 ## Basic terraform sanity check
 terraform/validate:
 ifeq ("12","$(word 2, $(subst ., ,$(TERRAFORM_VERSION)))")
-	echo "12"
+	@$(TERRAFORM) validate --help
 	@$(TERRAFORM) validate
 else
-	echo "11"
 	@$(TERRAFORM) validate -check-variables=false
 endif
 

--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -25,8 +25,7 @@ terraform/get-modules:
 ## Basic terraform sanity check
 terraform/validate:
 ifeq ("12","$(word 2, $(subst ., ,$(TERRAFORM_VERSION)))")
-	@$(TERRAFORM) validate --help
-	@$(TERRAFORM) validate
+	@echo "Terraform 0.12 does not support validate without skipping variables"
 else
 	@$(TERRAFORM) validate -check-variables=false
 endif

--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -24,7 +24,7 @@ terraform/get-modules:
 
 ## Basic terraform sanity check
 terraform/validate:
-ifeq ($(word 1, $(subst ., ,$(TERRAFORM_VERSION))),12)
+ifeq ($(word 2, $(subst ., ,$(TERRAFORM_VERSION))),12)
 	@$(TERRAFORM) validate;
 else
 	@$(TERRAFORM) validate -check-variables=false

--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -24,7 +24,11 @@ terraform/get-modules:
 
 ## Basic terraform sanity check
 terraform/validate:
+ifeq ($(word 1, $(subst ., ,$(TERRAFORM_VERSION))),12)
+	@$(TERRAFORM) validate;
+else
 	@$(TERRAFORM) validate -check-variables=false
+endif
 
 ## Lint check Terraform
 terraform/lint:

--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -25,10 +25,10 @@ terraform/get-modules:
 ## Basic terraform sanity check
 terraform/validate:
 ifeq ("12","$(word 2, $(subst ., ,$(TERRAFORM_VERSION)))")
-	echo $(TERRAFORM_VERSION)
-	@$(TERRAFORM) validate;
+	echo "12"
+	@$(TERRAFORM) validate
 else
-	echo $(TERRAFORM_VERSION)
+	echo "11"
 	@$(TERRAFORM) validate -check-variables=false
 endif
 

--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -24,7 +24,7 @@ terraform/get-modules:
 
 ## Basic terraform sanity check
 terraform/validate:
-ifeq ($(word 2, $(subst ., ,$(TERRAFORM_VERSION))),12)
+ifeq ("12","$(word 2, $(subst ., ,$(TERRAFORM_VERSION)))")
 	@$(TERRAFORM) validate;
 else
 	@$(TERRAFORM) validate -check-variables=false


### PR DESCRIPTION
## What
* Disable validation for terraform `0.12`

## Why
* Validation does not allow to skip variables check.