### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -14,8 +14,4 @@ jobs:
     - run: git remote set-url origin "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
     - run: git remote -v
     - run: git status
-    - run: git diff
-    - run: git add .
-    - run: git commit -m "Updated README"
-    - run: git push origin HEAD:add-actions
-
+    - run: git diff --exit-code || ( git add . && git commit -m "Updated README" && git push origin HEAD:add-actions )

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -13,9 +13,9 @@ jobs:
     - run: git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
     - run: git remote set-url origin "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
     - run: git remote -v
-    - run: git add .
-    - run: git commit -m "Updated README"
     - run: git status
     - run: git diff
-    - run: echo git push origin HEAD:${GITHUB_REF} --force
+    - run: git add .
+    - run: git commit -m "Updated README"
+    - run: git push origin HEAD:${GITHUB_REF} --force
 

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -10,9 +10,13 @@ jobs:
     - run: make readme/deps
     - run: make readme
     - run: printenv
-    - run: git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
-    - run: git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
-    - run: git remote set-url origin "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
-    - run: git remote -v
-    - run: git status
-    - run: git diff --exit-code || ( git add . && git commit -m "Updated README" && git push origin HEAD:add-actions )
+    - uses: cloudposse/actions/git-push@init
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}
+
+#    - run: git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+#    - run: git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+#    - run: git remote set-url origin "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
+#    - run: git remote -v
+#    - run: git status
+#    - run: git diff --exit-code || ( git add . && git commit -m "Updated README" && git push origin HEAD:${GITHUB_HEAD_REF} )

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -5,13 +5,19 @@ jobs:
     name: 'Rebuild README.md'
     runs-on: ubuntu-latest
     steps:
+    # Wake up on commands
     - uses: actions/bin/filter@master 
-      args: "issue_comment update/readme"
+      args: "issue_comment /readme"
+
+    # Checkout the current branch
     - uses: actions/checkout@master
-    - uses: cloudposse/build-harness@add-actions
+
+    # Rebuild the README.md from the README.yaml
+    - uses: cloudposse/build-harness@master
       with:
-        entrypoint: /usr/bin/make
         args: readme
+
+    # Push changes back to branch, if any
     - uses: cloudposse/actions/git-push@0.1.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 jobs:
   build:
     name: 'Rebuild README.md'
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - uses: cloudposse/build-harness@add-actions

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -13,5 +13,6 @@ jobs:
     - run: git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
     #- run: git remote set-url origin "https://${{GITHUB_ACTOR}}:${{GITHUB_TOKEN}}@github.com/${{GITHUB_REPOSITORY}}.git"
     - run: git remote set-url origin "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+    - run: git remote -v
     - run: git status
     - run: git diff

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -2,12 +2,14 @@ name: readme/build
 on: [pull_request]
 jobs:
   build:
+    name: 'Rebuild README.md'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - run: make readme/deps
-    - run: make readme
-    - run: printenv
+    - uses: cloudposse/build-harness@master
+      with:
+        entrypoint: /bin/make
+        args: readme
     - uses: cloudposse/actions/git-push@init
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: cloudposse/build-harness@master
       with:
-        entrypoint: /bin/make
+        entrypoint: /usr/bin/make
         args: readme
     - uses: cloudposse/actions/git-push@init
       env:

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -10,10 +10,8 @@ jobs:
     - run: make readme
     - run: printenv
     - uses: cloudposse/actions/git-push@init
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-#    - run: git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
-#    - run: git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 #    - run: git remote set-url origin "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
 #    - run: git remote -v
 #    - run: git status

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -1,6 +1,5 @@
 name: readme/build
 on: [pull_request]
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -5,9 +5,8 @@ jobs:
     name: 'Rebuild README.md'
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/actions/comment-filter@init
-      env:
-        GITHUB_COMMENT: "/build-harness readme"
+    - uses: actions/bin/filter@master 
+      args: "issue_comment update/readme"
     - uses: actions/checkout@master
     - uses: cloudposse/build-harness@add-actions
       with:

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -11,6 +11,7 @@ jobs:
     - run: make readme
     - run: git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
     - run: git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
-    - run: git remote set-url origin "https://${{GITHUB_ACTOR}}:${{GITHUB_TOKEN}}@github.com/${{GITHUB_REPOSITORY}}.git"
+    #- run: git remote set-url origin "https://${{GITHUB_ACTOR}}:${{GITHUB_TOKEN}}@github.com/${{GITHUB_REPOSITORY}}.git"
+    - run: git remote set-url origin "https://osterman:${{GITHUB_TOKEN}}@github.com/${{GITHUB_REPOSITORY}}.git"
     - run: git status
     - run: git diff

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -17,5 +17,5 @@ jobs:
     - run: git diff
     - run: git add .
     - run: git commit -m "Updated README"
-    - run: git push origin HEAD:${GITHUB_REF} --force
+    - run: git push origin HEAD:${GITHUB_REF}
 

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -7,4 +7,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - run: ls -l
+    - run: make readme
+    - run: git status
+    - run: git diff

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -12,7 +12,7 @@ jobs:
     - run: git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
     - run: git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
     #- run: git remote set-url origin "https://${{GITHUB_ACTOR}}:${{GITHUB_TOKEN}}@github.com/${{GITHUB_REPOSITORY}}.git"
-    - run: git remote set-url origin "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+    - run: git remote set-url origin "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
     - run: git remote -v
     - run: git status
     - run: git diff

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -5,6 +5,9 @@ jobs:
     name: 'Rebuild README.md'
     runs-on: ubuntu-latest
     steps:
+    - uses: cloudposse/actions/comment-filter@init
+      env:
+        GITHUB_COMMENT: "/build-harness readme"
     - uses: actions/checkout@master
     - uses: cloudposse/build-harness@add-actions
       with:

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -7,4 +7,4 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-	- run: ls -l
+    - run: ls -l

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -9,6 +9,7 @@ jobs:
     - uses: actions/checkout@master
     - run: make readme/deps
     - run: make readme
+    - run: printenv
     - run: git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
     - run: git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
     - run: git remote set-url origin "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -7,6 +7,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
+    - run: make readme/deps
     - run: make readme
     - run: git status
     - run: git diff

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -3,7 +3,6 @@ on: [pull_request]
 jobs:
   build:
     name: 'Rebuild README.md'
-    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - uses: cloudposse/build-harness@add-actions

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -1,5 +1,5 @@
 name: readme/build
-on: [pull_request]
+on: [issue_comment]
 jobs:
   build:
     name: 'Rebuild README.md'

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -12,8 +12,7 @@ jobs:
     - run: printenv
     - uses: cloudposse/actions/git-push@init
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}
-
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
 #    - run: git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
 #    - run: git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
 #    - run: git remote set-url origin "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -17,5 +17,5 @@ jobs:
     - run: git diff
     - run: git add .
     - run: git commit -m "Updated README"
-    - run: git push origin HEAD:${GITHUB_REF}
+    - run: git push origin HEAD:add-actions
 

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -11,8 +11,11 @@ jobs:
     - run: make readme
     - run: git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
     - run: git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
-    #- run: git remote set-url origin "https://${{GITHUB_ACTOR}}:${{GITHUB_TOKEN}}@github.com/${{GITHUB_REPOSITORY}}.git"
     - run: git remote set-url origin "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
     - run: git remote -v
+    - run: git add .
+    - run: git commit -m "Updated README"
     - run: git status
     - run: git diff
+    - run: echo git push origin HEAD:${GITHUB_REF} --force
+

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -1,0 +1,10 @@
+name: readme/build
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+	- run: ls -l

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -9,5 +9,8 @@ jobs:
     - uses: actions/checkout@master
     - run: make readme/deps
     - run: make readme
+    - run: git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+    - run: git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+    - run: git remote set-url origin "https://${{GITHUB_ACTOR}}:${{GITHUB_TOKEN}}@github.com/${{GITHUB_REPOSITORY}}.git"
     - run: git status
     - run: git diff

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: cloudposse/build-harness@master
+    - uses: cloudposse/build-harness@add-actions
       with:
         entrypoint: /usr/bin/make
         args: readme

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         entrypoint: /usr/bin/make
         args: readme
-    - uses: cloudposse/actions/git-push@init
+    - uses: cloudposse/actions/git-push@0.1.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         GIT_COMMIT_MESSAGE: "Updated README.md"

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -11,7 +11,4 @@ jobs:
     - uses: cloudposse/actions/git-push@init
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-#    - run: git remote set-url origin "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
-#    - run: git remote -v
-#    - run: git status
-#    - run: git diff --exit-code || ( git add . && git commit -m "Updated README" && git push origin HEAD:${GITHUB_HEAD_REF} )
+        GIT_COMMIT_MESSAGE: "Updated README.md"

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -1,5 +1,5 @@
 name: readme/build
-on: [issue_comment]
+on: [pull_request_review_comment]
 jobs:
   build:
     name: 'Rebuild README.md'

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -4,7 +4,6 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@master
     - run: make readme/deps

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -12,6 +12,6 @@ jobs:
     - run: git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
     - run: git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
     #- run: git remote set-url origin "https://${{GITHUB_ACTOR}}:${{GITHUB_TOKEN}}@github.com/${{GITHUB_REPOSITORY}}.git"
-    - run: git remote set-url origin "https://osterman:${{GITHUB_TOKEN}}@github.com/${{GITHUB_REPOSITORY}}.git"
+    - run: git remote set-url origin "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
     - run: git status
     - run: git diff

--- a/.github/workflows/rebuild-readme.yml
+++ b/.github/workflows/rebuild-readme.yml
@@ -1,5 +1,5 @@
 name: readme/build
-on: [pull_request_review_comment]
+on: [issue_comment]
 jobs:
   build:
     name: 'Rebuild README.md'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
 FROM golang:1.11-alpine3.10
+LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
+
+LABEL "com.github.actions.name"="Build Harness"
+LABEL "com.github.actions.description"="Run any build-harness make target"
+LABEL "com.github.actions.icon"="tool"
+LABEL "com.github.actions.color"="blue"
 
 RUN apk update && \
     apk --update add \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # Build Harness [![Build Status](https://travis-ci.org/cloudposse/build-harness.svg?branch=master)](https://travis-ci.org/cloudposse/build-harness) [![Latest Release](https://img.shields.io/github/release/cloudposse/build-harness.svg)](https://github.com/cloudposse/build-harness/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 
 
-This `build-harness` is a collection of Makefiles to facilitate building awesome Golang projects, Dockerfiles, Helm charts, and more.
+This `build-harness` is a collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more.
 It's designed to work with CI/CD systems such as Travis CI, CircleCI and Jenkins.
 
 
@@ -125,13 +125,13 @@ Available targets:
   geodesic/deploy                     Run a Jenkins Job to Deploy $(APP) with $(CANONICAL_TAG)
   git/aliases-update                  Update git aliases
   git/export                          Export git vars
+  git/submodules-update               Update submodules
   github/download-private-release     Download release from github
   github/download-public-release      Download release from github
   github/latest-release               Fetch the latest release tag from the GitHub API
   github/push-artifacts               Push all release artifacts to GitHub (Required: `GITHUB_TOKEN`)
   gitleaks/install                    Install gitleaks
   gitleaks/scan                       Scan current repository
-  git/submodules-update               Update submodules
   go/build                            Build binary
   go/build-all                        Build binary for all platforms
   go/clean                            Clean compiled binary
@@ -160,7 +160,6 @@ Available targets:
   helm/delete/failed                  Delete all failed releases in a `NAMESPACE` subject to `FILTER`
   helm/delete/namespace               Delete all releases in a `NAMEPSACE` as well as the namespace
   helm/delete/namespace/empty         Delete `NAMESPACE` if there are no releases in it
-  helmfile/install                    Install helmfile
   helm/install                        Install helm
   helm/repo/add                       Add $REPO_NAME from $REPO_ENDPOINT
   helm/repo/add-current               Add helm remote dev repos
@@ -173,16 +172,17 @@ Available targets:
   helm/repo/update                    Update repo info
   helm/serve/index                    Build index for serve helm charts
   helm/toolbox/upsert                 Install or upgrade helm tiller 
+  helmfile/install                    Install helmfile
   help                                Help screen
   help/all                            Display help for all targets
   help/short                          This help short screen
   jenkins/run-job-with-tag            Run a Jenkins Job with $(TAG)
   make/lint                           Lint all makefiles
   packages/delete                     Delete packages
-  packages/install/%                  Install package (e.g. helm, helmfile, kubectl)
   packages/install                    Install packages 
-  packages/reinstall/%                Reinstall package (e.g. helm, helmfile, kubectl)
+  packages/install/%                  Install package (e.g. helm, helmfile, kubectl)
   packages/reinstall                  Reinstall packages
+  packages/reinstall/%                Reinstall package (e.g. helm, helmfile, kubectl)
   packages/uninstall/%                Uninstall package (e.g. helm, helmfile, kubectl)
   readme                              Alias for readme/build
   readme/build                        Create README.md by building it from README.yaml

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # Build Harness [![Build Status](https://travis-ci.org/cloudposse/build-harness.svg?branch=master)](https://travis-ci.org/cloudposse/build-harness) [![Latest Release](https://img.shields.io/github/release/cloudposse/build-harness.svg)](https://github.com/cloudposse/build-harness/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 
 
-This `build-harness` is a collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more.
+This `build-harness` is a collection of Makefiles to facilitate building awesome Golang projects, Dockerfiles, Helm charts, and more.
 It's designed to work with CI/CD systems such as Travis CI, CircleCI and Jenkins.
 
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ on: [pull_request]
 jobs:
   build:
     name: 'Lint README.md'
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - uses: cloudposse/build-harness@master

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 
 This `build-harness` is a collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more.
-It's designed to work with CI/CD systems such as Travis CI, CircleCI and Jenkins.
+It's designed to work with CI/CD systems such as GitHub Actions, Codefresh, Travis CI, CircleCI and Jenkins.
 
 
 ---
@@ -60,6 +60,26 @@ This automatically exposes many new targets that you can leverage throughout you
 Run `make help` for a list of available targets.
 
 **NOTE:** the `/` is interchangable with the `:` in target names
+
+## GitHub Actions
+
+The `build-harness` is compatible with [GitHub Actions](https://github.com/features/actions).
+
+Here's an example of running `make readme/lint` 
+
+```
+name: build-harness/readme/lint
+on: [pull_request]
+jobs:
+  build:
+    name: 'Lint README.md'
+    steps:
+    - uses: actions/checkout@master
+    - uses: cloudposse/build-harness@master
+      with:
+        entrypoint: /usr/bin/make
+        args: readme/lint
+ ```
 
 ## Quick Start
 

--- a/README.yaml
+++ b/README.yaml
@@ -91,6 +91,7 @@ usage: |-
   jobs:
     build:
       name: 'Lint README.md'
+      runs-on: ubuntu-latest
       steps:
       - uses: actions/checkout@master
       - uses: cloudposse/build-harness@master

--- a/README.yaml
+++ b/README.yaml
@@ -57,7 +57,7 @@ screenshots:
 # Short description of this project
 description: |-
   This `build-harness` is a collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more.
-  It's designed to work with CI/CD systems such as Travis CI, CircleCI and Jenkins.
+  It's designed to work with CI/CD systems such as GitHub Actions, Codefresh, Travis CI, CircleCI and Jenkins.
 
 # Introduction to the project
 #introduction: |-
@@ -78,6 +78,26 @@ usage: |-
   Run `make help` for a list of available targets.
 
   **NOTE:** the `/` is interchangable with the `:` in target names
+
+  ## GitHub Actions
+  
+  The `build-harness` is compatible with [GitHub Actions](https://github.com/features/actions).
+
+  Here's an example of running `make readme/lint` 
+
+  ```
+  name: build-harness/readme/lint
+  on: [pull_request]
+  jobs:
+    build:
+      name: 'Lint README.md'
+      steps:
+      - uses: actions/checkout@master
+      - uses: cloudposse/build-harness@master
+        with:
+          entrypoint: /usr/bin/make
+          args: readme/lint
+   ```
 
 # Example usage
 examples: |-


### PR DESCRIPTION
## what
* Add action to automatically rebuild readme and push upstream
* Respond to `/readme` command. Note: `issue_comment` workflows use `master` workflow for security. See https://developer.github.com/actions/managing-workflows/workflow-configuration-options/#workflow-attributes

## why
* Keep readme up to date

## references

Here's everything you need to know to get started with actions:
- https://help.github.com/en/articles/workflow-syntax-for-github-actions
- https://help.github.com/en/articles/events-that-trigger-workflows
- https://help.github.com/en/articles/virtual-environments-for-github-actions
- https://feathericons.com/
- https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/#supported-feather-icons

## examples
- https://github.com/cirrus-actions/rebase
- https://github.com/pullreminders/assignee-to-reviewer-action

## depends on
* https://github.com/cloudposse/build-harness/pull/167