### PR TITLE
Fix regex in `Makefile.helpers`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,5 @@ WORKDIR /build-harness
 
 RUN make -s template/deps aws/install
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/usr/bin/make"]
 

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -44,7 +44,7 @@ help/short:
 
 # Generate help output from MAKEFILE_LIST
 help/generate:
-	@awk '/^[a-zA-Z\-\_0-9%:\\\/]+:/ { \
+	@awk '/^[a-zA-Z\_0-9%:\\\/-]+:/ { \
 	  helpMessage = match(lastLine, /^## (.*)/); \
 	  if (helpMessage) { \
 	    helpCommand = $$1; \

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 ## Usage
 
+
+
 At the top of your `Makefile` add, the following...
 
 ```make
@@ -288,7 +290,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2016-2018 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2016-2019 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -44,13 +44,13 @@ Available targets:
   geodesic/deploy                     Run a Jenkins Job to Deploy $(APP) with $(CANONICAL_TAG)
   git/aliases-update                  Update git aliases
   git/export                          Export git vars
-  git/submodules-update               Update submodules
   github/download-private-release     Download release from github
   github/download-public-release      Download release from github
   github/latest-release               Fetch the latest release tag from the GitHub API
   github/push-artifacts               Push all release artifacts to GitHub (Required: `GITHUB_TOKEN`)
   gitleaks/install                    Install gitleaks
   gitleaks/scan                       Scan current repository
+  git/submodules-update               Update submodules
   go/build                            Build binary
   go/build-all                        Build binary for all platforms
   go/clean                            Clean compiled binary
@@ -79,6 +79,7 @@ Available targets:
   helm/delete/failed                  Delete all failed releases in a `NAMESPACE` subject to `FILTER`
   helm/delete/namespace               Delete all releases in a `NAMEPSACE` as well as the namespace
   helm/delete/namespace/empty         Delete `NAMESPACE` if there are no releases in it
+  helmfile/install                    Install helmfile
   helm/install                        Install helm
   helm/repo/add                       Add $REPO_NAME from $REPO_ENDPOINT
   helm/repo/add-current               Add helm remote dev repos
@@ -91,17 +92,16 @@ Available targets:
   helm/repo/update                    Update repo info
   helm/serve/index                    Build index for serve helm charts
   helm/toolbox/upsert                 Install or upgrade helm tiller 
-  helmfile/install                    Install helmfile
   help                                Help screen
   help/all                            Display help for all targets
   help/short                          This help short screen
   jenkins/run-job-with-tag            Run a Jenkins Job with $(TAG)
   make/lint                           Lint all makefiles
   packages/delete                     Delete packages
-  packages/install                    Install packages 
   packages/install/%                  Install package (e.g. helm, helmfile, kubectl)
-  packages/reinstall                  Reinstall packages
+  packages/install                    Install packages 
   packages/reinstall/%                Reinstall package (e.g. helm, helmfile, kubectl)
+  packages/reinstall                  Reinstall packages
   packages/uninstall/%                Uninstall package (e.g. helm, helmfile, kubectl)
   readme                              Alias for readme/build
   readme/build                        Create README.md by building it from README.yaml


### PR DESCRIPTION
## what
* Move `-` character to end.
* Change entrypoint to `/usr/bin/make`
* Rebuilt the README

## why
* In regex, the `-` has a special meaning in a `[...]` character list. If it appears between any two characters, it implies a range. Therefore, it is supposed to appear last if you want to match for it. Not all regex handlers treat `\-` as an escaped dash.
* Use the `/usr/bin/make` default entry point because the `build-harness` is not intended to be a shell