### PR TITLE
fix templates path

### DIFF
--- a/modules/github/Makefile.init
+++ b/modules/github/Makefile.init
@@ -12,17 +12,17 @@ GITHUB_TEMPLATES = \
 
 $(GITHUB_TEMPLATES): $(addprefix $(BUILD_HARNESS_PATH)/templates/, $(GITHUB_TEMPLATES))
 	mkdir -p $(dir $@)
-	cp templates/$@ $@
+	cp $(BUILD_HARNESS_PATH)/templates/$@ $@
 	git add $@
 
 .github/auto-assign.yml: # do not overwrite config by default
 	mkdir -p $(dir $@)
-	cp templates/$@ $@
+	cp $(BUILD_HARNESS_PATH)/templates/$@ $@
 	git add $@
 
 .github/auto-label.yml: # do not overwrite config by default
 	mkdir -p $(dir $@)
-	cp templates/$@ $@
+	cp $(BUILD_HARNESS_PATH)/templates/$@ $@
 	git add $@
 
 github/init: $(GITHUB_TEMPLATES) .github/auto-assign.yml .github/auto-label.yml


### PR DESCRIPTION
## what
* prefix template path with `$(BUILD_HARNESS_PATH)` to make it absolute

## why
* when using `build-harness` in other projects, the relative path does not work