### PR TITLE
Allow target to be extended

### DIFF
--- a/modules/github/Makefile.init
+++ b/modules/github/Makefile.init
@@ -15,12 +15,12 @@ $(GITHUB_TEMPLATES): $(addprefix $(BUILD_HARNESS_PATH)/templates/, $(GITHUB_TEMP
 	cp $(BUILD_HARNESS_PATH)/templates/$@ $@
 	git ls-files --error-unmatch $@ 2>/dev/null || git add $@
 
-.github/auto-assign.yml: # do not overwrite config by default
+.github/auto-assign.yml:: # do not overwrite config by default
 	mkdir -p $(dir $@)
 	cp $(BUILD_HARNESS_PATH)/templates/$@ $@
 	git ls-files --error-unmatch $@ 2>/dev/null || git add $@
 
-.github/auto-label.yml: # do not overwrite config by default
+.github/auto-label.yml:: # do not overwrite config by default
 	mkdir -p $(dir $@)
 	cp $(BUILD_HARNESS_PATH)/templates/$@ $@
 	git ls-files --error-unmatch $@ 2>/dev/null || git add $@


### PR DESCRIPTION
## what
* Allow the `.github/*.yml` targets to be extended

## why
* It's convenient to have custom generators for these files

## references
* https://stackoverflow.com/questions/7891097/what-are-double-colon-rules-in-a-makefile-for