### PR TITLE
Document module extension architecture merged in PR #158

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ Available targets:
   travis/docker-tag-and-push          Tag & Push according Travis environment variables
 
 ```
+## Extending `build-harness` with targets from another repo
+
+It is possible to extend `build-harness` with targets and entire modules of your own, without having to fork or modify `build-harness` itself.
+This might be useful if, for example, you wanted to maintain some tooling that was specific to your environment that didn't have enough general applicability to be part of the main project.
+This makes it so you don't necessarily need to fork `build-harness` itself - you can place a repo defined by the environment variable `BUILD_HARNESS_EXTENSIONS_PATH` (a filesystem peer of `build-harness` named `build-harness-extensions` by default) and populate it with tools in the same `Makefile` within `module` structure as `build-harness` has.
+Modules will be combined and available with a unified `make` command. 
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -118,6 +118,7 @@ quickstart: |-
 # Other files to include in this README from the project folder
 include:
   - "docs/targets.md"
+  - "docs/extensions.md"
 
 # Contributors to this project
 contributors:

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,6 +1,6 @@
 ## Extending `build-harness` with targets from another repo
 
-It is possible to extend `build-harness` with targets and entire modules of your own, without having to fork or modify `build-harness` itself.
+It is possible to extend the `build-harness` with targets and entire modules of your own, without having to fork or modify `build-harness` itself.
 This might be useful if, for example, you wanted to maintain some tooling that was specific to your environment that didn't have enough general applicability to be part of the main project.
 This makes it so you don't necessarily need to fork `build-harness` itself - you can place a repo defined by the environment variable `BUILD_HARNESS_EXTENSIONS_PATH` (a filesystem peer of `build-harness` named `build-harness-extensions` by default) and populate it with tools in the same `Makefile` within `module` structure as `build-harness` has.
 Modules will be combined and available with a unified `make` command. 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,6 @@
+## Extending `build-harness` with targets from another repo
+
+It is possible to extend `build-harness` with targets and entire modules of your own, without having to fork or modify `build-harness` itself.
+This might be useful if, for example, you wanted to maintain some tooling that was specific to your environment that didn't have enough general applicability to be part of the main project.
+This makes it so you don't necessarily need to fork `build-harness` itself - you can place a repo defined by the environment variable `BUILD_HARNESS_EXTENSIONS_PATH` (a filesystem peer of `build-harness` named `build-harness-extensions` by default) and populate it with tools in the same `Makefile` within `module` structure as `build-harness` has.
+Modules will be combined and available with a unified `make` command. 


### PR DESCRIPTION
## what
* Document, via README yaml architecture, the recent addition of module extension capability

## why
* Functionality was merged before documentation was included in an abundance of enthusiasm

## references
* See PR https://github.com/cloudposse/build-harness/pull/158

