### PR TITLE
Add `slash-command-dispatch` GitHub workflow template and Make target

### DIFF
--- a/modules/github/Makefile.init
+++ b/modules/github/Makefile.init
@@ -4,6 +4,7 @@ GITHUB_TEMPLATES = \
 	.github/workflows/auto-assign.yml \
 	.github/workflows/auto-label.yml \
 	.github/workflows/auto-readme.yml \
+	.github/workflows/slash-command-dispatch.yml \
 	.github/ISSUE_TEMPLATE/config.yml \
 	.github/PULL_REQUEST_TEMPLATE.md \
 	.github/ISSUE_TEMPLATE/feature_request.md \
@@ -25,4 +26,9 @@ $(GITHUB_TEMPLATES): $(addprefix $(BUILD_HARNESS_PATH)/templates/, $(GITHUB_TEMP
 	cp $(BUILD_HARNESS_PATH)/templates/$@ $@
 	git ls-files --error-unmatch $@ 2>/dev/null || git add $@
 
-github/init: $(GITHUB_TEMPLATES) .github/auto-assign.yml .github/auto-label.yml
+.github/slash-command-dispatch.yml:: # do not overwrite config by default
+	mkdir -p $(dir $@)
+	cp $(BUILD_HARNESS_PATH)/templates/$@ $@
+	git ls-files --error-unmatch $@ 2>/dev/null || git add $@
+
+github/init: $(GITHUB_TEMPLATES) .github/auto-assign.yml .github/auto-label.yml .github/slash-command-dispatch.yml

--- a/templates/.github/workflows/slash-command-dispatch.yml
+++ b/templates/.github/workflows/slash-command-dispatch.yml
@@ -1,0 +1,20 @@
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Slash Command Dispatch
+        uses: cloudposse/actions/github/slash-command-dispatch@0.9.0
+        with:
+          token: ${{ secrets.GITHUB_BOT_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: cloudposse/actions
+          commands: rebuild-readme
+          permission: none
+          issue-type: pull-request


### PR DESCRIPTION
## what
* Add `slash-command-dispatch` GitHub workflow template and Make target

## why
* Automatically include  `slash-command-dispatch.yml` file into each repo
* `slash-command-dispatch` workflow will be executed in each repo after issuing the comment `/rebuild-readme` in pull requests
* It will dispatch the event to `cloudposse/actions/.github/workflows/rebuld-readme-command.yml`, which in turn will rebuild README.md from README.yaml and commit the changes back to the PR repo


