### PR TITLE
fix make[1]: *** No rule to make target error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ include $(BUILD_HARNESS_PATH)/Makefile.*
 include $(BUILD_HARNESS_PATH)/modules/*/bootstrap.Makefile*
 include $(BUILD_HARNESS_PATH)/modules/*/Makefile*
 # Don't fail if there are no build harness extensions
+# Wildcard conditions is to fixes `make[1]: *** No rule to make target` error
+ifneq ($(wildcard $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/*/Makefile*),)
 -include $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/*/Makefile*
+endif
 
 # For backwards compatibility with all of our other projects that use build-harness
 init::


### PR DESCRIPTION
## what
* Check to see if extensions directory exists before attempting to do include

## why
* Make was giving an annoying error `make[1]: *** No rule to make target`

## references
* https://github.com/vanvalenlab/kiosk/issues/210#issuecomment-576972179
* Bug introduced in #158 