### PR TITLE
Make OS name available in an environment variable in build-harness namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
+export OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 export BUILD_HARNESS_PATH ?= $(shell 'pwd')
 export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/../build-harness-extensions
+export BUILD_HARNESS_OS ?= $(OS)
 export BUILD_HARNESS_ARCH ?= $(shell uname -m | sed 's/x86_64/amd64/g')
-export OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 export SELF ?= $(MAKE)
 export PATH := $(BUILD_HARNESS_PATH)/vendor:$(PATH)
 export DOCKER_BUILD_FLAGS ?=


### PR DESCRIPTION
## what
 * Define `BUILD_HARNESS_OS` as the result of `OS` in the top-level Makefile
 * Retain compatibility with prior use of `OS` while providing new capability

## why
 * Use the `BUILD_HARNESS_` environment variable namespace for operating system
 * Be consistent with other system-level environment variables (such as `BUILD_HARNESS_ARCH`)
