### PR TITLE
suppress detachedhead advise on versioned tag install

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -10,4 +10,4 @@ if [ "$BUILD_HARNESS_PROJECT" ] && [ -d "$BUILD_HARNESS_PROJECT" ]; then
 fi
 
 echo "Cloning ${GITHUB_REPO}#${BUILD_HARNESS_BRANCH}..."
-git clone -b $BUILD_HARNESS_BRANCH $GITHUB_REPO
+git clone -c advice.detachedHead=false --depth=1 -b $BUILD_HARNESS_BRANCH $GITHUB_REPO


### PR DESCRIPTION
## what
* update install.sh to suppress git detached head advise when installing specific version of build harness

## why
* Prettier make init output
* Saves 9 or 10 lines of output text making for less busy setup feedback
