### PR TITLE
slash-command-dispatch updates

### DIFF
--- a/templates/.github/workflows/slash-command-dispatch.yml
+++ b/templates/.github/workflows/slash-command-dispatch.yml
@@ -13,7 +13,7 @@ jobs:
         uses: cloudposse/actions/github/slash-command-dispatch@0.15.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-          reaction-token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
           repository: cloudposse/actions
           commands: rebuild-readme, terraform-fmt
           permission: none

--- a/templates/.github/workflows/slash-command-dispatch.yml
+++ b/templates/.github/workflows/slash-command-dispatch.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Slash Command Dispatch
-        uses: cloudposse/actions/github/slash-command-dispatch@0.12.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.13.0
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/.github/workflows/slash-command-dispatch.yml
+++ b/templates/.github/workflows/slash-command-dispatch.yml
@@ -10,10 +10,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Slash Command Dispatch
-        uses: cloudposse/actions/github/slash-command-dispatch@0.13.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.15.0
         with:
-          token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          reaction-token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           repository: cloudposse/actions
           commands: rebuild-readme, terraform-fmt
           permission: none


### PR DESCRIPTION
## what
* secrets for token being renamed 
* slash-command-dispatch version bumped

## why
* Secrets names that start with GITHUB_ are no longer supported by GitHub

## references
* https://github.com/cloudposse/actions/pull/20
