### PR TITLE
Fixes #149, tf/lint on mac xargs does not support --no-run-if-empty

### DIFF
--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -32,8 +32,13 @@ endif
 
 ## Lint check Terraform
 terraform/lint:
+ifeq ($(OS), darwin)
+	@FAIL=`$(TERRAFORM) fmt -write=false | xargs -n 1 printf '\t- %s\n'`; \
+	[ -z "$$FAIL" ] || (echo "Terraform configuration needs linting. Run '$(TERRAFORM) fmt'"; echo $$FAIL; exit 1)
+else
 	@FAIL=`$(TERRAFORM) fmt -write=false | xargs --no-run-if-empty -n 1 printf '\t- %s\n'`; \
 	[ -z "$$FAIL" ] || (echo "Terraform configuration needs linting. Run '$(TERRAFORM) fmt'"; echo $$FAIL; exit 1)
+endif
 
 ## Upgrade all terraform module sources
 terraform/upgrade-modules: packages/install/json2hcl


### PR DESCRIPTION

## what
* Fixes `make terraform/lint` on Mac OSX which was failing. 

## why
* The `terrform/lint` target uses the `--no-run-if-empty` flag, which is not available on the default Mac/BSD `xargs`, but is available on Linux `xargs`.

## references
* Fixes / Closes #149
* This should be a direct fix and not just hide the problem as "On the Mac, if there is no input from stdin, it will not execute the command. On Linux, it will execute it without any argument." Quote taken from https://ylan.segal-family.com/blog/2016/10/19/subtleties-of-xargs-on-mac-and-linux/. 

