### PR TITLE
build image on releases

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -5,7 +5,9 @@ on:
       - master
   pull_request: 
     types: [opened, synchronize, reopened]
-
+  release:
+    types:
+      - created
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## what
* restore functionality of building docker images on releases

## why
* It broke when we switched to github actions in #213 