### PR TITLE
Fix assert-set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,6 @@ WORKDIR /build-harness
 
 RUN make -s bash/lint make/lint
 RUN make -s template/deps aws/install terraform/install readme/deps
-#RUN make -s go/deps-build go/deps-dev
+RUN make -s go/deps-build go/deps-dev
 
 ENTRYPOINT ["/usr/bin/make"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.4-alpine3.10
+FROM golang:1.14.4-alpine3.11
 LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
 
 LABEL "com.github.actions.name"="Build Harness"
@@ -31,7 +31,8 @@ RUN apk --update --no-cache add \
       chamber@cloudposse \
       helm@cloudposse \
       helmfile@cloudposse \
-      codefresh@cloudposse
+      codefresh@cloudposse && \
+    sed -i /PATH=/d /etc/profile
 
 ADD ./ /build-harness/
 
@@ -40,7 +41,7 @@ ENV INSTALL_PATH /usr/local/bin
 WORKDIR /build-harness
 
 RUN make -s bash/lint make/lint
-RUN make -s template/deps aws/install terraform/install go/deps-build go/deps-dev readme/deps 
+RUN make -s template/deps aws/install terraform/install readme/deps
+#RUN make -s go/deps-build go/deps-dev
 
 ENTRYPOINT ["/usr/bin/make"]
-

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -13,16 +13,26 @@ green = $(shell echo -e '\x1b[32;01m$1\x1b[0m')
 yellow = $(shell echo -e '\x1b[33;01m$1\x1b[0m')
 red = $(shell echo -e '\x1b[33;31m$1\x1b[0m')
 
-
 # Ensures that a variable is defined and non-empty
 define assert-set
-  @[ -n "$${$1}" ] || (echo "$(1) not defined in $(@)"; exit 1)
+  @[ "$(if $($(1)),set,unset)" == "set" ] || (echo "$(1) not defined in $(@)"; exit 1)
 endef
 
 # Ensures that a variable is undefined
 define assert-unset
-  @[ -z "$($1)" ] || (echo "$(1) should not be defined in $(@)"; exit 1)
+  @[ "$(if $($1),set,unset)" == "unset" ] || (echo "$(1) should not be defined in $(@)"; exit 1)
 endef
+
+test/assert-set:
+	$(call assert-set,PATH)
+	@echo assert-set PASS
+
+test/assert-unset:
+	$(call assert-unset,JKAHSDKJAHSDJKHASKD)
+	@echo assert-unset PASS
+
+test/assert: test/assert-set test/assert-unset
+	@exit 0
 
 default:: $(DEFAULT_HELP_TARGET)
 	@exit 0

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -14,7 +14,7 @@ yellow = $(shell echo -e '\x1b[33;01m$1\x1b[0m')
 red = $(shell echo -e '\x1b[33;31m$1\x1b[0m')
 
 
-# Ensures that a variable is defined
+# Ensures that a variable is defined and non-empty
 define assert-set
   @[ -n "$${$1}" ] || (echo "$(1) not defined in $(@)"; exit 1)
 endef

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -15,12 +15,12 @@ red = $(shell echo -e '\x1b[33;31m$1\x1b[0m')
 
 # Ensures that a variable is defined and non-empty
 define assert-set
-  @[ "$(if $($(1)),set,unset)" == "set" ] || (echo "$(1) not defined in $(@)"; exit 1)
+  @$(if $($(1)),,$(error $(1) not defined in $(@)))
 endef
 
 # Ensures that a variable is undefined
 define assert-unset
-  @[ "$(if $($1),set,unset)" == "unset" ] || (echo "$(1) should not be defined in $(@)"; exit 1)
+  @$(if $($1),$(error $(1) should not be defined in $(@)),)
 endef
 
 test/assert-set:

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -16,7 +16,7 @@ red = $(shell echo -e '\x1b[33;31m$1\x1b[0m')
 
 # Ensures that a variable is defined
 define assert-set
-  @[ -n "$($1)" ] || (echo "$(1) not defined in $(@)"; exit 1)
+  @[ -n "$${$1}" ] || (echo "$(1) not defined in $(@)"; exit 1)
 endef
 
 # Ensures that a variable is undefined

--- a/modules/go/Makefile
+++ b/modules/go/Makefile
@@ -1,1 +1,1 @@
-GO:= $(shell which go 2>/dev/null)
+GO := $(shell which go 2>/dev/null)


### PR DESCRIPTION
## what
* Use native make conditional to test if variable is set
* Add tests for assertions
* Upgrade go

## why

This was a tricky one to figure out! but got it working now consistently
Previously we did the evaluation of the variable in shell, but this led to escaping problems Now we evaluate the variable in `make` and return a safe string to compare in shell.

A bad env like the one below would lead to a syntax error.
```
 export CF_COMMIT_MESSAGE='Try all kinds of `characters()`that""maybe'"'"'cause problems'
```

Cannot do something naive like `[ -n "$${$(1)}" ]` because not all make variables are exported, so they cannot be accessed in the shell. 

Now we get meaningful errors like this one that say in the `Makefile` on line 46 that `FOO` was not defined.

```
Makefile:46: *** FOO not defined in testme.  Stop.
```
