### PR TITLE
Support running all targets in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ENV INSTALL_PATH /usr/local/bin
 WORKDIR /build-harness
 
 RUN make -s bash/lint make/lint
-RUN make -s template/deps aws/install terraform/install readme/deps
+RUN make -s template/deps aws/install terraform/install packages/install/terraform-docs readme/deps
 RUN make -s go/deps-build go/deps-dev
 
 ENTRYPOINT ["/usr/bin/make"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN apk --update --no-cache add \
 ADD ./ /build-harness/
 
 ENV INSTALL_PATH /usr/local/bin
+ENV BUILD_HARNESS_PATH /build-harness
 
 WORKDIR /build-harness
 

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -41,6 +41,7 @@ clean::
 	   echo rm -rf $(BUILD_HARNESS_PATH)
 else
 # If we're using docker, then pass all targets to docker
+.DEFAULT_GOAL : init
 .PHONY : init
 ## Init build-harness
 init::

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -19,7 +19,6 @@ endif
 
 ifneq ($(wildcard $(BUILD_HARNESS_PATH)),)
 # We deliberately use the conditional above to avoid triggering `%` target when include not found
-$(warning $(BUILD_HARNESS_PATH)/Makefile overrides BUILD_HARNESS_DOCKER_ENABLED=true)
 -include $(BUILD_HARNESS_PATH)/Makefile
 endif
 

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -54,7 +54,6 @@ init::
 	              --name build-harness \
 	              --rm \
 	              -e BUILD_HARNESS_DOCKER_ENABLED=false \
-	              -e BUILD_HARNESS_PATH=/build-harness \
 	              -e AWS_ACCESS_KEY_ID \
 	              -e AWS_SECRET_ACCESS_KEY \
 	              -e AWS_SESSION_TOKEN \

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -1,14 +1,35 @@
+#
+# This is a shim installed automatically by the build-harness
+# https://github.com/cloudposse/build-harness
+#
+
 export SHELL = /bin/bash
+export BUILD_HARNESS_ORIGIN ?= https://raw.githubusercontent.com
 export BUILD_HARNESS_ORG ?= cloudposse
 export BUILD_HARNESS_PROJECT ?= build-harness
 export BUILD_HARNESS_BRANCH ?= master
 export BUILD_HARNESS_PATH ?= $(shell until [ -d "$(BUILD_HARNESS_PROJECT)" ] || [ "`pwd`" == '/' ]; do cd ..; done; pwd)/$(BUILD_HARNESS_PROJECT)
--include $(BUILD_HARNESS_PATH)/Makefile
+export BUILD_HARNESS_DOCKER_ENABLED ?= false
+export BUILD_HARNESS_DOCKER_TAG ?= latest
 
+ifneq ($(wildcard .makeenv),)
+# We deliberately use the conditional above to avoid triggering `%` target when include not found
+-include .makeenv
+endif
+
+ifneq ($(wildcard $(BUILD_HARNESS_PATH)),)
+# We deliberately use the conditional above to avoid triggering `%` target when include not found
+$(warning $(BUILD_HARNESS_PATH)/Makefile overrides BUILD_HARNESS_DOCKER_ENABLED=true)
+-include $(BUILD_HARNESS_PATH)/Makefile
+endif
+
+ifneq ($(BUILD_HARNESS_DOCKER_ENABLED),true)
+
+.DEFAULT_GOAL : init
 .PHONY : init
 ## Init build-harness
 init::
-	@curl --retry 5 --fail --silent --retry-delay 1 https://raw.githubusercontent.com/$(BUILD_HARNESS_ORG)/$(BUILD_HARNESS_PROJECT)/$(BUILD_HARNESS_BRANCH)/bin/install.sh | \
+	@curl --retry 5 --fail --silent --retry-delay 1 $(BUILD_HARNESS_ORIGIN)/$(BUILD_HARNESS_ORG)/$(BUILD_HARNESS_PROJECT)/$(BUILD_HARNESS_BRANCH)/bin/install.sh | \
 		bash -s "$(BUILD_HARNESS_ORG)" "$(BUILD_HARNESS_PROJECT)" "$(BUILD_HARNESS_BRANCH)"
 
 .PHONY : clean
@@ -16,4 +37,27 @@ init::
 clean::
 	@[ "$(BUILD_HARNESS_PATH)" == '/' ] || \
 	 [ "$(BUILD_HARNESS_PATH)" == '.' ] || \
+	 [ "$(BUILD_HARNESS_PATH)" == '//$(BUILD_HARNESS_PROJECT)' ] || \
 	   echo rm -rf $(BUILD_HARNESS_PATH)
+else
+# If we're using docker, then pass all targets to docker
+.PHONY : init
+## Init build-harness
+init::
+	@docker pull $(BUILD_HARNESS_ORG)/$(BUILD_HARNESS_PROJECT):$(BUILD_HARNESS_DOCKER_TAG)
+	@exit 0
+
+## Pass all targets through the `build-harness` (and envs so we can run inside of build-harness)
+%:
+	$(info $@: Running inside of $(BUILD_HARNESS_ORG)/$(BUILD_HARNESS_PROJECT):$(BUILD_HARNESS_DOCKER_TAG))
+	@docker run --workdir /opt \
+	              --name build-harness \
+	              --rm \
+	              -e BUILD_HARNESS_DOCKER_ENABLED=false \
+	              -e BUILD_HARNESS_PATH=/build-harness \
+	              -e AWS_ACCESS_KEY_ID \
+	              -e AWS_SECRET_ACCESS_KEY \
+	              -e AWS_SESSION_TOKEN \
+	              -v $(CURDIR):/opt \
+	              $(BUILD_HARNESS_ORG)/$(BUILD_HARNESS_PROJECT):$(BUILD_HARNESS_DOCKER_TAG) $(@)
+endif


### PR DESCRIPTION
## what
* Add support for a new `BUILD_HARNESS_DOCKER_ENABLED` flag (disabled by default)
* Run build harness inside of a docker shell

## why
* Many users lack the requisite tools locally to run the build-harness effectively
* Using docker enables us to ship a working combination of tools