### PR TITLE
Adds terraform/oh-dot-thirteen-upgrade target

### DIFF
--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -43,3 +43,6 @@ endif
 ## Upgrade all terraform module sources
 terraform/upgrade-modules: packages/install/json2hcl
 	@$(BUILD_HARNESS_PATH)/bin/upgrade_terraform_modules.sh all
+
+terraform/oh-dot-thirteen-upgrade:
+	[ ! -f versions.tf ] || sed -i '' 's/~> 0.12.0/>= 0.12.0, < 0.14.0/' versions.tf


### PR DESCRIPTION
## what
* This adds a new make target for upgrading the versions.tf file's `required_version` parameter to be inclusive of 0.13.

## why
* To support Terraform v0.13.* as all CloudPosse modules are currently 

