### PR TITLE
Update README template to pass lint and add gh action superlinter 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+
+jobs:
+  lint-readme:
+    name: readme
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: cloudposse/build-harness@0.38.0
+        with:
+          entrypoint: /usr/bin/make
+          args: readme/lint
+
+  super-linter:
+    name: superlinter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Lint Code Base
+        uses: docker://github/super-linter:v3
+        env:
+          VALIDATE_ALL_CODEBASE: false

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Run `make help` for a list of available targets.
 
 The `build-harness` is compatible with [GitHub Actions](https://github.com/features/actions).
 
-Here's an example of running `make readme/lint` 
+Here's an example of running `make readme/lint`
 
 ```yaml
 name: build-harness/readme/lint
@@ -412,8 +412,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Sarkis][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis][sarkis_homepage] | [![Alexander Babai][alebabai_avatar]][alebabai_homepage]<br/>[Alexander Babai][alebabai_homepage] | [![Jon Boulle][jonboulle_avatar]][jonboulle_homepage]<br/>[Jon Boulle][jonboulle_homepage] |
-|---|---|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Sarkis][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis][sarkis_homepage] | [![Alexander Babai][alebabai_avatar]][alebabai_homepage]<br/>[Alexander Babai][alebabai_homepage] | [![Jon Boulle][jonboulle_avatar]][jonboulle_homepage]<br/>[Jon Boulle][jonboulle_homepage] | [![Marcin Brański][3h4x_avatar]][3h4x_homepage]<br/>[Marcin Brański][3h4x_homepage] |
+|---|---|---|---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
@@ -427,6 +427,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [alebabai_avatar]: https://img.cloudposse.com/150x150/https://github.com/alebabai.png
   [jonboulle_homepage]: https://github.com/jonboulle
   [jonboulle_avatar]: https://img.cloudposse.com/150x150/https://github.com/jonboulle.png
+  [3h4x_homepage]: https://github.com/3h4x
+  [3h4x_avatar]: https://img.cloudposse.com/150x150/https://github.com/3h4x.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -365,22 +365,24 @@ Copyright © 2016-2020 [Cloud Posse, LLC](https://cloudposse.com)
 
 See [LICENSE](LICENSE) for full details.
 
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
+```text
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-      https://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The `build-harness` is compatible with [GitHub Actions](https://github.com/featu
 
 Here's an example of running `make readme/lint` 
 
-```
+```yaml
 name: build-harness/readme/lint
 on: [pull_request]
 jobs:

--- a/README.yaml
+++ b/README.yaml
@@ -1,11 +1,11 @@
 ---
-# 
+#
 # This is the canonical configuration for the `README.md`
 # Run `make readme` to rebuild the `README.md`
 #
 
 # Name of this project
-name: Build Harness 
+name: Build Harness
 
 # Logo for this project
 #logo: docs/logo.png
@@ -19,7 +19,7 @@ copyrights:
     url: "https://cloudposse.com"
     year: "2016"
 
-# Canonical GitHub repo 
+# Canonical GitHub repo
 github_repo: cloudposse/build-harness
 
 # Badges to display
@@ -56,7 +56,7 @@ screenshots:
   - name: "demo"
     description: "Example of using the `build-harness` to build a docker image"
     url: "https://cdn.rawgit.com/cloudposse/build-harness/master/docs/demo.svg"
- 
+
 # Short description of this project
 description: |-
   This `build-harness` is a collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more.
@@ -83,10 +83,10 @@ usage: |-
   **NOTE:** the `/` is interchangable with the `:` in target names
 
   ## GitHub Actions
-  
+ 
   The `build-harness` is compatible with [GitHub Actions](https://github.com/features/actions).
 
-  Here's an example of running `make readme/lint` 
+  Here's an example of running `make readme/lint`
 
   ```yaml
   name: build-harness/readme/lint
@@ -137,3 +137,5 @@ contributors:
     github: "alebabai"
   - name: "Jon Boulle"
     github: "jonboulle"
+  - name: "Marcin Brański"
+    github: "3h4x"

--- a/README.yaml
+++ b/README.yaml
@@ -88,7 +88,7 @@ usage: |-
 
   Here's an example of running `make readme/lint` 
 
-  ```
+  ```yaml
   name: build-harness/readme/lint
   on: [pull_request]
   jobs:

--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -224,6 +224,7 @@ Copyright © 2017-{{ time.Now.Year }} [Cloud Posse, LLC](https://cpco.io/copyrig
 
 See [LICENSE](LICENSE) for full details.
 
+```text
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
@@ -232,7 +233,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-  [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+  https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
@@ -240,6 +241,7 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
+```
 {{ end }}
 {{ if eq (ds "config").license "CC-BY-NC-SA-4.0" }}
 ## License
@@ -268,6 +270,7 @@ Distribution of the work or derivative of the work in any standard (paper) book 
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+```text
 The MIT License (MIT)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -289,6 +292,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 Source: <https://opensource.org/licenses/MIT>
+```
 {{ end }}
 
 {{ if eq (ds "config").license "ISC" }}
@@ -296,6 +300,7 @@ Source: <https://opensource.org/licenses/MIT>
 
 [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
 
+```text
 ISC License (ISC)
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
@@ -303,6 +308,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 Source: <https://opensource.org/licenses/ISC>
+```
 {{ end }}
 
 {{ if eq (ds "config").license "GPL3" }}
@@ -310,6 +316,7 @@ Source: <https://opensource.org/licenses/ISC>
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
+```text
 GNU GENERAL PUBLIC LICENSE
 Version 3, 29 June 2007
 
@@ -325,6 +332,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
+```
 {{ end }}
 
 ## Trademarks

--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -224,22 +224,22 @@ Copyright © 2017-{{ time.Now.Year }} [Cloud Posse, LLC](https://cpco.io/copyrig
 
 See [LICENSE](LICENSE) for full details.
 
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-      https://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
 {{ end }}
 {{ if eq (ds "config").license "CC-BY-NC-SA-4.0" }}
 ## License

--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -232,7 +232,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-  https://www.apache.org/licenses/LICENSE-2.0
+  [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an


### PR DESCRIPTION
## what
- superlinter fix

## why
In PR against `terraform-example-module` I ran into [issue with superlint](https://github.com/cloudposse/terraform-example-module/pull/3/checks?check_run_id=928328375)
> ERROR:[README.md:240 MD046/code-block-style Code block style [Expected: fenced; Actual: indented]]

Here is documentation about it:
https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md046---code-block-style

Passing check after manual changes introduced in this PR:
https://github.com/cloudposse/terraform-example-module/pull/3/checks?check_run_id=928418728