### PR TITLE
Updates to auto-release.yml files to include PR body + use minor > patch as default

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -29,7 +29,10 @@ categories:
       - 'bug'
       - 'hotfix'
 
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-template: |
+  ## $TITLE @$AUTHOR (#$NUMBER)
+
+  $BODY
 
 template: |
   $CHANGES

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -16,7 +16,7 @@ version-resolver:
       - 'bugfix'
       - 'bug'
       - 'hotfix'
-  default: patch
+  default: minor
 
 categories:
   - title: '🚀 Enhancements'

--- a/templates/.github/auto-release.yml
+++ b/templates/.github/auto-release.yml
@@ -29,7 +29,10 @@ categories:
       - 'bug'
       - 'hotfix'
 
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-template: |
+  ## $TITLE @$AUTHOR (#$NUMBER)
+
+  $BODY
 
 template: |
   $CHANGES

--- a/templates/.github/auto-release.yml
+++ b/templates/.github/auto-release.yml
@@ -16,7 +16,7 @@ version-resolver:
       - 'bugfix'
       - 'bug'
       - 'hotfix'
-  default: patch
+  default: minor
 
 categories:
   - title: '🚀 Enhancements'


### PR DESCRIPTION
## what

* Updates change-template to include the PR body 
* Updates to bump the minor as the default instead of bumping patch 

## why
* Our PR bodies typically have good information in them due to our PR body template being simple and straightforward. It's good to include that in our release notes as most folks likely won't check the PR itself. 
* We do minor releases much more frequently than patch so using minor as our default makes sense to save us time in regards to merging without a label. 
