### PR TITLE
Fixing superlint terraform docs check for inherited markdown files

### DIFF
--- a/modules/docs/Makefile
+++ b/modules/docs/Makefile
@@ -17,4 +17,6 @@ docs/targets.md: docs/deps
 .PHONY : docs/terraform.md
 ## Update `docs/terraform.md` from `terraform-docs`
 docs/terraform.md: docs/deps packages/install/terraform-docs
-	@terraform-docs md . > $@
+	@echo "<!-- markdownlint-disable -->" > $@
+	@terraform-docs md . >> $@
+	@echo "<!-- markdownlint-restore -->" >> $@


### PR DESCRIPTION
## what
* Fixes lint error in inherited markdown file
> [ERROR ]   [docs/terraform.md:1 MD041/first-line-heading/first-line-h1 First line in file should be a top level heading [Context: "## Requirements"]]

## references
* https://github.com/cloudposse/terraform-aws-eks-iam-role/runs/1024081306#step:4:171
