### PR TITLE
new target to remove upper bound for terraform core version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Available targets:
   terraform/get-plugins               Ensure all plugins can be fetched
   terraform/install                   Install terraform
   terraform/lint                      Lint check Terraform
+  terraform/remove-upper-bound        Rewrite versions.tf to remove upper bound for terraform core version constraint (like this ">= 0.12.0, < 0.14.0")
   terraform/rewrite-module-source     Rewrite the *.tf files to use registry notation for modules sources
   terraform/upgrade-modules           Upgrade all terraform module sources
   terraform/validate                  Basic terraform sanity check

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -118,6 +118,7 @@ Available targets:
   terraform/get-plugins               Ensure all plugins can be fetched
   terraform/install                   Install terraform
   terraform/lint                      Lint check Terraform
+  terraform/remove-upper-bound        Rewrite versions.tf to remove upper bound for terraform core version constraint (like this ">= 0.12.0, < 0.14.0")
   terraform/rewrite-module-source     Rewrite the *.tf files to use registry notation for modules sources
   terraform/upgrade-modules           Upgrade all terraform module sources
   terraform/validate                  Basic terraform sanity check

--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -49,3 +49,9 @@ terraform/rewrite-module-source:
 	@sed -i -E 's,"git::https://github.com/(.*?)/terraform-([^-]*?)-(.*?).git\?ref=tags/(.*?)","\1/\3/\2"\n  version     = "\4",g' $$(find . -type f -name '*.tf')
 	@$(TERRAFORM) fmt .
 	@$(TERRAFORM) fmt examples/complete
+
+## Rewrite versions.tf to remove upper bound for terraform core version constraint (like this ">= 0.12.0, < 0.14.0")
+terraform/remove-upper-bound:
+	@sed -i -E 's,required_version\s*\=\s*\"(.*?)(\,\s*<.*)",required_version = "\1",g' $$(find . -type f -name 'versions.tf')
+	@$(TERRAFORM) fmt .
+	@$(TERRAFORM) fmt examples/complete


### PR DESCRIPTION
## what
* new target to remove upper bound for terraform core version constraint

## why
* a lot of modules have constraint like this ">= 0.12.0, < 0.14.0", which blocks to migrate to TF 0.14