### PR TITLE
Add renovate config to Terraform modules

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,13 +15,15 @@ jobs:
       if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository
       id: prepare
       run: |
-        TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
-        SLIM_TAGS=${{ github.repository }}:slim-sha-${GITHUB_SHA:0:7}
+        COMMIT_SHA="${GITHUB_SHA}"
         if [[ $GITHUB_REF == refs/tags/* ]]; then
           VERSION=${GITHUB_REF#refs/tags/}
         elif [[ $GITHUB_REF == refs/pull/* ]]; then
           VERSION=pr-${{ github.event.pull_request.number }}-merge
+          COMMIT_SHA=${{ github.event.pull_request.head.sha }}
         fi
+        TAGS=${{ github.repository }}:sha-${COMMIT_SHA:0:7}
+        SLIM_TAGS=${{ github.repository }}:slim-sha-${COMMIT_SHA:0:7}
         if [[ -n $VERSION ]]; then
           TAGS="$TAGS,${{ github.repository }}:${VERSION}"
           SLIM_TAGS="$SLIM_TAGS,${{ github.repository }}:slim-${VERSION}"

--- a/modules/github/Makefile.init
+++ b/modules/github/Makefile.init
@@ -13,7 +13,8 @@ GITHUB_TEMPLATES = \
 GITHUB_TERRAFORM_TEMPLATES = .github/workflows/chatops.yml \
 	.github/workflows/auto-context.yml \
 	.github/workflows/auto-readme.yml \
-	.github/mergify.yml
+	.github/mergify.yml \
+	.github/renovate.json
 
 
 $(GITHUB_TEMPLATES): $(addprefix $(BUILD_HARNESS_PATH)/templates/, $(GITHUB_TEMPLATES))

--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -69,7 +69,7 @@ terraform/rewrite-module-source:
 
 terraform/rewrite-readme-source: TERRAFORM = terraform-0.13
 terraform/rewrite-readme-source:
-	@sed -i -E 's,^(\s*)source\s+=\s+"git::https://github.com/([^/]+)/terraform-([^-]+)-(.+).git\?ref=(tags/)?master",\1source = "\2/\4/\3"\n\1# Cloud Posse recommends pinning every module to a specific version\n\1# version     = "x.x.x",g' README.yaml
+	@sed -i -E 's,^(\s*)source\s+=\s+"git::https://github.com/([^/]+)/terraform-([^-]+)-(.+).git\?ref=(tags/)?master",\1source = "\2/\4/\3"\n\1# Cloud Posse recommends pinning every module to a specific version\n\1# version = "x.x.x",g' README.yaml
 
 ## Rewrite versions.tf to remove upper bound for terraform core version constraint (like this ">= 0.12.0, < 0.14.0")
 ## and convert "~>" constraints to ">=".

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -51,10 +51,10 @@ shell builder: BUILD_HARNESS_DOCKER_TAG ?= $(shell $(BUILD_HARNESS_DOCKER_SHA_TA
 shell builder: build-harness/run/docker
 	@exit 0
 
-.PHONY: shell-slim builder-slim pr/prepare tf14-upgrade
+.PHONY: shell-slim builder-slim pr/auto-format tf14-upgrade
 
-shell-slim builder-slim tf14-upgrade pr/prepare: BUILD_HARNESS_DOCKER_SHA_TAG ?= $(shell $(BUILD_HARNESS_DOCKER_SHA_TAG_CMD))
-shell-slim builder-slim tf14-upgrade pr/prepare: BUILD_HARNESS_DOCKER_TAG ?= \
+shell-slim builder-slim tf14-upgrade pr/auto-format: BUILD_HARNESS_DOCKER_SHA_TAG ?= $(shell $(BUILD_HARNESS_DOCKER_SHA_TAG_CMD))
+shell-slim builder-slim tf14-upgrade pr/auto-format: BUILD_HARNESS_DOCKER_TAG ?= \
 	$(shell docker inspect --type=image $(BUILD_HARNESS_DOCKER_IMAGE):$(BUILD_HARNESS_DOCKER_SHA_TAG) >/dev/null 2>&1 && \
 	echo "$(BUILD_HARNESS_DOCKER_SHA_TAG) " || echo "slim-$(BUILD_HARNESS_DOCKER_SHA_TAG)")
 
@@ -63,10 +63,10 @@ shell-slim builder-slim: ARGS := $(if $(TARGETS),$(TARGETS),-l || true)
 shell-slim builder-slim: ENTRYPOINT := $(if $(TARGETS),/usr/bin/make,/bin/bash)
 shell-slim builder-slim: build-harness/run/docker
 
-pr/prepare tf14-upgrade : ENTRYPOINT := /usr/bin/make
+pr/auto-format tf14-upgrade : ENTRYPOINT := /usr/bin/make
 
-pr/prepare: ARGS := terraform/fmt readme
-pr/prepare: build-harness/run/docker
+pr/auto-format: ARGS := terraform/fmt readme
+pr/auto-format: build-harness/run/docker
 
 tf14-upgrade: export TERRAFORM_FORCE_README := true
 tf14-upgrade: ARGS := github/init terraform/v14-rewrite

--- a/templates/terraform/.github/renovate.json
+++ b/templates/terraform/.github/renovate.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "config:base",
+    ":preserveSemverRanges"
+  ],
+  "labels": ["auto-update"],
+  "enabledManagers": ["terraform"],
+  "terraform": {
+    "ignorePaths": ["**/context.tf", "examples/**"]
+  }
+}
+


### PR DESCRIPTION
## what
- Add `.github/renovate.json` configuration to Terraform modules via `github/init`
- Tag PR Docker builds with PR SHA, not merge SHA
- Rename `make` target to `pr/auto-format`

## why
- Properly config Renovate bot
- Make it easy to find Docker image that goes with PR commit