### PR TITLE
RUNNER_DOCKER_IMAGE was missing for 'builder' target

### DIFF
--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -48,6 +48,7 @@ build-harness/shell builder tester: TARGETS ?= $(TARGET)
 build-harness/shell builder tester: ARGS := $(if $(TARGETS),$(TARGETS),-l || true)
 build-harness/shell builder tester: ENTRYPOINT := $(if $(TARGETS),/usr/bin/make,/bin/bash)
 build-harness/shell builder: RUNNER_DOCKER_TAG ?= $(shell $(BUILD_HARNESS_DOCKER_SHA_TAG_CMD))
+build-harness/shell builder: RUNNER_DOCKER_IMAGE ?= $(BUILD_HARNESS_DOCKER_IMAGE)
 build-harness/shell builder: build-harness/runner
 	@exit 0
 


### PR DESCRIPTION
## what
* `RUNNER_DOCKER_IMAGE` added to make `builder` target work properly

## why
* #268 have a bug with missing `RUNNER_DOCKER_IMAGE` env variable, generating bad docker command
