### PR TITLE
[auto-context] Open PR (as cloudpossebot) when context.tf changes

### DIFF
--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -77,11 +77,17 @@ tf14-upgrade: export TERRAFORM_FORCE_README := true
 tf14-upgrade: ARGS := github/init terraform/v14-rewrite
 tf14-upgrade: build-harness/runner
 
-tester: TEST_HARNESS_DOCKER_IMAGE ?= cloudposse/test-harness
-tester: TEST_HARNESS_DOCKER_TAG ?= latest
+.PHONY: tester tester/pull
+
+tester tester/pull: TEST_HARNESS_DOCKER_IMAGE ?= cloudposse/test-harness
+tester tester/pull: TEST_HARNESS_DOCKER_TAG ?= latest
 tester: RUNNER_DOCKER_IMAGE ?= $(TEST_HARNESS_DOCKER_IMAGE)
 tester: RUNNER_DOCKER_TAG ?= $(TEST_HARNESS_DOCKER_TAG)
 tester: build-harness/runner
+
+tester/pull:
+	docker pull $(TEST_HARNESS_DOCKER_IMAGE):$(TEST_HARNESS_DOCKER_TAG)
+
 
 .PHONY: build-harness/runner
 

--- a/templates/terraform/.github/workflows/auto-context.yml
+++ b/templates/terraform/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "::set-output name=create_pull_request=true"
+            echo "::set-output name=create_pull_request::true"
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."
@@ -38,6 +38,8 @@ jobs:
       uses: cloudposse/actions/github/create-pull-request@0.22.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
+        author: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         commit-message: Update context.tf from origin source
         title: Update context.tf
         body: |-


### PR DESCRIPTION
## what
- [auto-context] Open PR (as cloudpossebot) when `context.tf` changes
- Add `tester/pull` `make` target to pull latest `test-harness` Docker image

## why
- Enable automatic merging of update
- Easy way to ensure you have the latest `test-harness` image

## references
- Fix partly tested in https://github.com/cloudposse/terraform-aws-rds/pull/86 and https://github.com/cloudposse/terraform-aws-rds/pull/87


