### PR TITLE
Adds auto-init capability using the bootstrap include directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ RUN update-alternatives --set terraform /usr/share/terraform/$DEFAULT_TERRAFORM_
   cp -p /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform /build-harness/vendor/terraform
 
 COPY ./ /build-harness/
-RUN touch /.dockerenv
 
 ENV INSTALL_PATH /usr/local/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN update-alternatives --set terraform /usr/share/terraform/$DEFAULT_TERRAFORM_
   cp -p /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform /build-harness/vendor/terraform
 
 COPY ./ /build-harness/
+RUN touch /.dockerenv
 
 ENV INSTALL_PATH /usr/local/bin
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ export SELF ?= $(MAKE)
 export PATH := $(BUILD_HARNESS_PATH)/vendor:$(PATH)
 export DOCKER_BUILD_FLAGS ?=
 
+# Forces auto-init off to avoid invoking the macro on recursive $(MAKE)
+export BUILD_HARNESS_AUTO_INIT = false
+
 # Debug should not be defaulted to a value because some cli consider any value as `true` (e.g. helm)
 export DEBUG ?=
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ Typically, the `build-harness` project requires running `make init` before any o
 
 Alternatively, the "auto-init" feature can automatically run the `init` logic for you to install the `build-harness` and help keep the install up-to-date. This feature is enabled using the env or Makefile variable `BUILD_HARNESS_AUTO_INIT=true`. By default, this feature is disabled; to enable it, you must set the variable yourself.
 
+**Note:** The "auto-init" feature is a convenience for running `make` interactively. Regardless of your setting of `BUILD_HARNESS_AUTO_INIT`, "auto-init" will be disabled if `make` is running inside a Docker container. Scripts and automation should continue to call `make init` explicitly. 
+
 ```make
 BUILD_HARNESS_AUTO_INIT = true
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,46 @@ This might be useful if, for example, you wanted to maintain some tooling that w
 This makes it so you don't necessarily need to fork `build-harness` itself - you can place a repo defined by the environment variable `BUILD_HARNESS_EXTENSIONS_PATH` (a filesystem peer of `build-harness` named `build-harness-extensions` by default) and populate it with tools in the same `Makefile` within `module` structure as `build-harness` has.
 Modules will be combined and available with a unified `make` command. 
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
+## Using the "auto-init" feature
+
+Typically, the `build-harness` project requires running `make init` before any of the Makefile targets can be invoked. The `init` target will "install" the `build-harness` project and "include" the `Makefile` from the `build-harness` project.
+
+Alternatively, the "auto-init" feature can automatically run the `init` logic for you to install the `build-harness` and help keep the install up-to-date. This feature is enabled using the env or Makefile variable `BUILD_HARNESS_AUTO_INIT=true`. By default, this feature is disabled; to enable it, you must set the variable yourself.
+
+```make
+BUILD_HARNESS_AUTO_INIT = true
+
+-include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+```
+
+The "auto-init" feature will _also_ keep the install up-to-date. It will check the value of `BUILD_HARNESS_BRANCH`, get the commit ID, compare that to the current checkout, and update the clone if they differ. A useful side-effect is that it becomes easy to pin to versions of the `build-harness` from your own project, and let the `build-harness` update itself as you update the pin:
+
+```make
+BUILD_HARNESS_AUTO_INIT = true
+BUILD_HARNESS_BRANCH = {TAG}
+
+-include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+```
+
+Now when you run `make` the project will update itself to use the version specified by the `BUILD_HARNESS_BRANCH` value:
+
+```sh
+$ make help
+Removing existing build-harness
+Cloning https://github.com/cloudposse/build-harness.git#{TAG}...
+Cloning into 'build-harness'...
+remote: Enumerating objects: 143, done.
+remote: Counting objects: 100% (143/143), done.
+remote: Compressing objects: 100% (118/118), done.
+remote: Total 143 (delta 7), reused 71 (delta 3), pack-reused 0
+Receiving objects: 100% (143/143), 85.57 KiB | 2.09 MiB/s, done.
+Resolving deltas: 100% (7/7), done.
+Available targets:
+
+  aws/install                         Install aws cli bundle
+```
+<!-- markdownlint-restore -->
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -122,6 +122,7 @@ quickstart: |-
 include:
   - "docs/targets.md"
   - "docs/extensions.md"
+  - "docs/auto-init.md"
 
 # Contributors to this project
 contributors:

--- a/docs/auto-init.md
+++ b/docs/auto-init.md
@@ -1,0 +1,40 @@
+<!-- markdownlint-disable -->
+## Using the "auto-init" feature
+
+Typically, the `build-harness` project requires running `make init` before any of the Makefile targets can be invoked. The `init` target will "install" the `build-harness` project and "include" the `Makefile` from the `build-harness` project.
+
+Alternatively, the "auto-init" feature can automatically run the `init` logic for you to install the `build-harness` and help keep the install up-to-date. This feature is enabled using the env or Makefile variable `BUILD_HARNESS_AUTO_INIT=true`. By default, this feature is disabled; to enable it, you must set the variable yourself.
+
+```make
+BUILD_HARNESS_AUTO_INIT = true
+
+-include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+```
+
+The "auto-init" feature will _also_ keep the install up-to-date. It will check the value of `BUILD_HARNESS_BRANCH`, get the commit ID, compare that to the current checkout, and update the clone if they differ. A useful side-effect is that it becomes easy to pin to versions of the `build-harness` from your own project, and let the `build-harness` update itself as you update the pin:
+
+```make
+BUILD_HARNESS_AUTO_INIT = true
+BUILD_HARNESS_BRANCH = {TAG}
+
+-include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+```
+
+Now when you run `make` the project will update itself to use the version specified by the `BUILD_HARNESS_BRANCH` value:
+
+```sh
+$ make help
+Removing existing build-harness
+Cloning https://github.com/cloudposse/build-harness.git#{TAG}...
+Cloning into 'build-harness'...
+remote: Enumerating objects: 143, done.
+remote: Counting objects: 100% (143/143), done.
+remote: Compressing objects: 100% (118/118), done.
+remote: Total 143 (delta 7), reused 71 (delta 3), pack-reused 0
+Receiving objects: 100% (143/143), 85.57 KiB | 2.09 MiB/s, done.
+Resolving deltas: 100% (7/7), done.
+Available targets:
+
+  aws/install                         Install aws cli bundle
+```
+<!-- markdownlint-restore -->

--- a/docs/auto-init.md
+++ b/docs/auto-init.md
@@ -5,6 +5,8 @@ Typically, the `build-harness` project requires running `make init` before any o
 
 Alternatively, the "auto-init" feature can automatically run the `init` logic for you to install the `build-harness` and help keep the install up-to-date. This feature is enabled using the env or Makefile variable `BUILD_HARNESS_AUTO_INIT=true`. By default, this feature is disabled; to enable it, you must set the variable yourself.
 
+**Note:** The "auto-init" feature is a convenience for running `make` interactively. Regardless of your setting of `BUILD_HARNESS_AUTO_INIT`, "auto-init" will be disabled if `make` is running inside a Docker container. Scripts and automation should continue to call `make init` explicitly. 
+
 ```make
 BUILD_HARNESS_AUTO_INIT = true
 

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -108,7 +108,6 @@ Available targets:
   readme/build                        Create README.md by building it from README.yaml
   readme/init                         Create basic minimalistic .README.md template file
   readme/lint                         Verify the `README.md` is up to date
-  readme/generate-related-references  Generate related references block (e.i. `related`) in the README.yaml
   semver/export                       Export semver vars
   slack/notify                        Send webhook notification to slack
   slack/notify/build                  Send notification to slack using "build" template

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -37,6 +37,10 @@ if [[ \
 ]]; then \
 	echo "[.build-harness]: In $(BUILD_HARNESS_PROJECT) docker container, skipping auto-init" ;\
 elif [[ \
+	grep -q docker /proc/1/cgroup 2>/dev/null \
+]]; then \
+	echo "[.build-harness]: In unknown docker container, skipping auto-init" ;\
+elif [[ \
 	"$(BUILD_HARNESS_PATH)" != "$(BUILD_HARNESS_PATH_LOCAL)" && \
 	-f "$(BUILD_HARNESS_PATH)/Makefile" \
 ]]; then \

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -29,6 +29,10 @@ endef
 # checkout does not match BUILD_HARNESS_BRANCH
 define harness_auto_init
 if [[ \
+	-f "/.dockerenv" && -f "/$(BUILD_HARNESS_PROJECT)/Makefile" \
+]]; then \
+	: ;\
+elif [[ \
 	"$(BUILD_HARNESS_PATH)" != "$(BUILD_HARNESS_PATH_LOCAL)" && \
 	-f "$(BUILD_HARNESS_PATH)/Makefile" \
 ]]; then \

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -4,21 +4,52 @@
 #
 
 export SHELL = /bin/bash
-export BUILD_HARNESS_PATH ?= $(shell until [ -d "$(BUILD_HARNESS_PROJECT)" ] || [ "`pwd`" == '/' ]; do cd ..; done; pwd)/$(BUILD_HARNESS_PROJECT)
 export BUILD_HARNESS_ORG ?= cloudposse
 export BUILD_HARNESS_PROJECT ?= build-harness
 export BUILD_HARNESS_DOCKER_IMAGE ?= $(BUILD_HARNESS_ORG)/$(BUILD_HARNESS_PROJECT)
 export BUILD_HARNESS_BRANCH ?= master
+export BUILD_HARNESS_CLONE_URL ?= https://github.com/$(BUILD_HARNESS_ORG)/$(BUILD_HARNESS_PROJECT).git
 # It is kind of expensive to figure out the Docker SHA tag, so we just define the command here, and only call it when needed
 export BUILD_HARNESS_DOCKER_SHA_TAG_CMD := git -C "$(BUILD_HARNESS_PATH)" log -n 1 --format=sha-%h 2>/dev/null || echo latest
 
--include $(BUILD_HARNESS_PATH)/Makefile
+# Resolves BUILD_HARNESS_PATH to BUILD_HARNESS_PATH_LOCAL when BUILD_HARNESS_PATH does not exist
+BUILD_HARNESS_PATH ?= $(shell until [ -d "$(BUILD_HARNESS_PROJECT)" ] || [ "`pwd`" == '/' ]; do cd ..; done; pwd)/$(BUILD_HARNESS_PROJECT)
+BUILD_HARNESS_PATH_LOCAL := $(PWD)/$(BUILD_HARNESS_PROJECT)
+export BUILD_HARNESS_PATH := $(or $(wildcard $(BUILD_HARNESS_PATH)),$(BUILD_HARNESS_PATH_LOCAL))
+
+# Macro to clone/install BUILD_HARNESS_PROJECT
+define harness_install
+curl --retry 5 --fail --silent --retry-delay 1 \
+	https://raw.githubusercontent.com/$(BUILD_HARNESS_ORG)/$(BUILD_HARNESS_PROJECT)/$(BUILD_HARNESS_BRANCH)/bin/install.sh | \
+	bash -s "$(BUILD_HARNESS_ORG)" "$(BUILD_HARNESS_PROJECT)" "$(BUILD_HARNESS_BRANCH)"
+endef
+
+# Macro to auto-init the BUILD_HARNESS_PROJECT with the `include` directive
+# Tests if BUILD_HARNESS_PROJECT does not yet exist, or if it does exist but the
+# checkout does not match BUILD_HARNESS_BRANCH
+define harness_auto_init
+if [[ \
+	"$(BUILD_HARNESS_PATH)" != "$(BUILD_HARNESS_PATH_LOCAL)" && \
+	-f "$(BUILD_HARNESS_PATH)/Makefile" \
+]]; then \
+	: ;\
+elif [[ \
+	"$(BUILD_HARNESS_PATH)" == "$(BUILD_HARNESS_PATH_LOCAL)" && \
+	-f "$(BUILD_HARNESS_PATH)/Makefile" && \
+	"$$(git -C '$(BUILD_HARNESS_PATH_LOCAL)' ls-remote '$(BUILD_HARNESS_CLONE_URL)' '$(BUILD_HARNESS_BRANCH)' | cut -f1)" == "$$(git -C '$(BUILD_HARNESS_PATH_LOCAL)' rev-parse HEAD)" \
+]]; then \
+	: ;\
+else \
+	$(harness_install) ;\
+fi
+endef
+
+-include $(shell $(harness_auto_init) >&2 ; echo $(BUILD_HARNESS_PATH)/Makefile)
 
 .PHONY : init
 ## Init build-harness
 init::
-	@curl --retry 5 --fail --silent --retry-delay 1 https://raw.githubusercontent.com/$(BUILD_HARNESS_ORG)/$(BUILD_HARNESS_PROJECT)/$(BUILD_HARNESS_BRANCH)/bin/install.sh | \
-		bash -s "$(BUILD_HARNESS_ORG)" "$(BUILD_HARNESS_PROJECT)" "$(BUILD_HARNESS_BRANCH)"
+	@ $(harness_install)
 
 .PHONY : clean
 ## Clean build-harness

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -18,6 +18,9 @@ BUILD_HARNESS_PATH ?= $(shell until [ -d "$(BUILD_HARNESS_PROJECT)" ] || [ "`pwd
 BUILD_HARNESS_PATH_LOCAL := $(PWD)/$(BUILD_HARNESS_PROJECT)
 export BUILD_HARNESS_PATH := $(or $(wildcard $(BUILD_HARNESS_PATH)),$(BUILD_HARNESS_PATH_LOCAL))
 
+# Toggles the auto-init feature
+BUILD_HARNESS_AUTO_INIT ?= false
+
 # Macro to clone/install BUILD_HARNESS_PROJECT
 define harness_install
 curl --retry 5 --fail --silent --retry-delay 1 \
@@ -49,7 +52,7 @@ else \
 fi
 endef
 
--include $(shell $(harness_auto_init) >&2 ; echo $(BUILD_HARNESS_PATH)/Makefile)
+-include $(if $(findstring true,$(BUILD_HARNESS_AUTO_INIT)),$(shell $(harness_auto_init) >&2)) $(BUILD_HARNESS_PATH)/Makefile
 
 .PHONY : init
 ## Init build-harness

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -33,7 +33,7 @@ endef
 # checkout does not match BUILD_HARNESS_BRANCH
 define harness_auto_init
 if [[ \
-	-f "/.dockerenv" && -f "/$(BUILD_HARNESS_PROJECT)/Makefile" \
+	-f "/build-harness/Makefile" || -f "/$(BUILD_HARNESS_PROJECT)/Makefile" \
 ]]; then \
 	echo "[.build-harness]: In $(BUILD_HARNESS_PROJECT) docker container, skipping auto-init" ;\
 elif [[ \

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -35,18 +35,18 @@ define harness_auto_init
 if [[ \
 	-f "/.dockerenv" && -f "/$(BUILD_HARNESS_PROJECT)/Makefile" \
 ]]; then \
-	: ;\
+	echo "[.build-harness]: In $(BUILD_HARNESS_PROJECT) docker container, skipping auto-init" ;\
 elif [[ \
 	"$(BUILD_HARNESS_PATH)" != "$(BUILD_HARNESS_PATH_LOCAL)" && \
 	-f "$(BUILD_HARNESS_PATH)/Makefile" \
 ]]; then \
-	: ;\
+	echo "[.build-harness]: Using external $(BUILD_HARNESS_PATH), skipping auto-init" ;\
 elif [[ \
 	"$(BUILD_HARNESS_PATH)" == "$(BUILD_HARNESS_PATH_LOCAL)" && \
 	-f "$(BUILD_HARNESS_PATH)/Makefile" && \
 	"$$(git -C '$(BUILD_HARNESS_PATH_LOCAL)' ls-remote '$(BUILD_HARNESS_CLONE_URL)' '$(BUILD_HARNESS_BRANCH)' | cut -f1)" == "$$(git -C '$(BUILD_HARNESS_PATH_LOCAL)' rev-parse HEAD)" \
 ]]; then \
-	: ;\
+	echo "[.build-harness]: Clone of $(BUILD_HARNESS_PROJECT) is up-to-date, skipping auto-init" ;\
 else \
 	$(harness_install) ;\
 fi

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -4,6 +4,7 @@
 #
 
 export SHELL = /bin/bash
+export PWD = $(shell pwd)
 export BUILD_HARNESS_ORG ?= cloudposse
 export BUILD_HARNESS_PROJECT ?= build-harness
 export BUILD_HARNESS_DOCKER_IMAGE ?= $(BUILD_HARNESS_ORG)/$(BUILD_HARNESS_PROJECT)


### PR DESCRIPTION
## what

These changes will automatically run the `make init` workflow, and keep the clone up-to-date with the target branch/tag.

## why

1. People on my team kept forgetting to run `make init`, and it proved sufficiently frustrating (and often) that I figured I'd try to automate it.

2. This makes it possible for the build-harness to update itself automatically. The user's Makefile can include `BUILD_HARNESS_BRANCH=<tag>` and `BUILD_HARNESS_AUTO_INIT=true`, and they can have a mechanism that updates that tag value, and the auto-init logic will ensure that the checkout is updated automatically.
