### PR TITLE
approvers now allowed to review all *.tf files

### DIFF
--- a/templates/.github/CODEOWNERS
+++ b/templates/.github/CODEOWNERS
@@ -15,9 +15,9 @@
 
 # Cloud Posse must review any changes to standard context definition,
 # but some changes can be rubber-stamped.
-**/context.tf   @cloudposse/engineering @cloudposse/approvers
-README.md       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
-docs/*.md       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+**/*.tf       @cloudposse/engineering @cloudposse/approvers
+README.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+docs/*.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 
 # Cloud Posse Admins must review all changes to CODEOWNERS or the mergify configuration
 .github/mergify.yml @cloudposse/admins

--- a/templates/.github/CODEOWNERS
+++ b/templates/.github/CODEOWNERS
@@ -16,6 +16,7 @@
 # Cloud Posse must review any changes to standard context definition,
 # but some changes can be rubber-stamped.
 **/*.tf       @cloudposse/engineering @cloudposse/approvers
+README.yaml   @cloudposse/engineering @cloudposse/approvers
 README.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 docs/*.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 


### PR DESCRIPTION
## what
* approvers now allowed to review all *.tf files

## why
* we have not given Mergify permission to merge changes to the .tf files. So all the Renovate PRs will require manual approval.
