### PR TITLE
Remove generate-related-references target from auto-format

### DIFF
--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -68,7 +68,7 @@ build-harness/shell-slim builder-slim: build-harness/runner
 
 pr/auto-format tf14-upgrade : ENTRYPOINT := /usr/bin/make
 
-pr/auto-format pr/auto-format/host: ARGS := terraform/fmt readme/generate-related-references readme
+pr/auto-format pr/auto-format/host: ARGS := terraform/fmt readme
 pr/auto-format: build-harness/runner
 pr/auto-format/host: 
 	$(MAKE) $(ARGS)


### PR DESCRIPTION
## what
- Remove `generate-related-references` target from auto-format added in #282

## why
- Target cannot be built by currently deployed auto-format workflow

## references

[This version of `auto-format.yaml`](https://github.com/cloudposse/build-harness/blob/0.56.0/templates/terraform/.github/workflows/auto-format.yml) is currently deployed in nearly all Cloud Posse Terraform modules. It runs auto-format on `build-harness:slim-latest`. The `generate-related-references` requires Python 3 which is not installed in the slim image. We either need to abandon the idea of the slim image or deploy updated `auto-format.yaml` that uses the full image to do auto-format.