### PR TITLE
Add `kubectl@cloudposse` to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN curl -fsSL --retry 3 https://apk.cloudposse.com/install.sh | bash
 RUN apk --update --no-cache add \
       chamber@cloudposse \
       gomplate@cloudposse \
+      kubectl@cloudposse \
       helm@cloudposse \
       helmfile@cloudposse \
       codefresh@cloudposse \

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017-2019 Cloud Posse, LLC
+   Copyright 2017-2021 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2016-2021-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2016-2021 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2016-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2016-2021-2021 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -17,7 +17,7 @@ license: "APACHE2"
 copyrights:
   - name: "Cloud Posse, LLC"
     url: "https://cloudposse.com"
-    year: "2016-2021"
+    year: "2016"
 
 # Canonical GitHub repo
 github_repo: cloudposse/build-harness

--- a/README.yaml
+++ b/README.yaml
@@ -17,7 +17,7 @@ license: "APACHE2"
 copyrights:
   - name: "Cloud Posse, LLC"
     url: "https://cloudposse.com"
-    year: "2016"
+    year: "2016-2021"
 
 # Canonical GitHub repo
 github_repo: cloudposse/build-harness
@@ -83,7 +83,7 @@ usage: |-
   **NOTE:** the `/` is interchangable with the `:` in target names
 
   ## GitHub Actions
- 
+
   The `build-harness` is compatible with [GitHub Actions](https://github.com/features/actions).
 
   Here's an example of running `make readme/lint`

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -108,7 +108,6 @@ Available targets:
   readme/build                        Create README.md by building it from README.yaml
   readme/init                         Create basic minimalistic .README.md template file
   readme/lint                         Verify the `README.md` is up to date
-  readme/generate-related-references  Generate related references block (e.i. `related`) in the README.yaml
   semver/export                       Export semver vars
   slack/notify                        Send webhook notification to slack
   slack/notify/build                  Send notification to slack using "build" template


### PR DESCRIPTION
## what
* Add `kubectl@cloudposse` to Dockerfile

## why
* Codefresh pipelines use `cloudposse/build-harness` Docker image to deploy helmfile using `kubectl` to switch context
* No need to add `kubectl` to all pipeline steps


