### PR TITLE
add conditional to related section or README template

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,13 +315,14 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
-
 ## Related Projects
 
 Check out these related projects.
 
 - [Packages](https://github.com/cloudposse/packages) - Cloud Posse installer and distribution of native apps
 - [Dev Harness](https://github.com/cloudposse/dev) - Cloud Posse Local Development Harness
+
+
 
 
 ## References

--- a/README.md
+++ b/README.md
@@ -315,14 +315,13 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
 
 - [Packages](https://github.com/cloudposse/packages) - Cloud Posse installer and distribution of native apps
 - [Dev Harness](https://github.com/cloudposse/dev) - Cloud Posse Local Development Harness
-
-
 
 
 ## References

--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -188,12 +188,14 @@ Like this project? Please give it a ★ on [our GitHub]({{ printf "https://githu
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 {{ end }}
+{{ if has (ds "config") "related" }}
 ## Related Projects
 
 Check out these related projects.
 {{ range $related := (ds "config").related }}
 {{ printf "- [%s](%s) - %s" $related.name $related.url $related.description }}{{ end }}
 
+{{ end}}
 {{ end}}
 {{ if has (ds "config") "references" }}
 

--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -195,8 +195,8 @@ Check out these related projects.
 {{ range $related := (ds "config").related }}
 {{ printf "- [%s](%s) - %s" $related.name $related.url $related.description }}{{ end }}
 
-{{ end}}
-{{ end}}
+{{- end}}
+{{- end}}
 {{ if has (ds "config") "references" }}
 
 ## References


### PR DESCRIPTION
## what
* Add a conditional around the `related` section of the readme template

## why
* It is currently throwing an error when `related` is not present

```json
{"level":"error","error":"template: /build-harness/templates/README.md.gotmpl:194:25: executing \"/build-harness/templates/README.md.gotmpl\" at <\"config\">: map has no entry for key \"related\"","time":"2021-05-14T17:04:06Z"}
```
