### PR TITLE
Add Terraform versions 0.15 and 1.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,8 @@ RUN apk --update --no-cache add \
       helmfile@cloudposse \
       codefresh@cloudposse \
       terraform-0.11@cloudposse terraform-0.12@cloudposse \
-      terraform-0.13@cloudposse terraform-0.14@cloudposse terraform-0.15@cloudposse \
+      terraform-0.13@cloudposse terraform-0.14@cloudposse \
+      terraform-0.15@cloudposse terraform-1@cloudposse \
       terraform-config-inspect@cloudposse \
       terraform-docs@cloudposse \
       vert@cloudposse \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -28,6 +28,7 @@ RUN curl -fsSL --retry 3 https://apk.cloudposse.com/install.sh | bash
 RUN apk --no-cache add \
       gomplate@cloudposse \
       terraform-0.12@cloudposse terraform-0.13@cloudposse terraform-0.14@cloudposse \
+      terraform-0.15@cloudposse terraform-1@cloudposse \
       terraform-config-inspect@cloudposse \
       terraform-docs@cloudposse \
       vert@cloudposse

--- a/README.md
+++ b/README.md
@@ -315,14 +315,13 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
 
 - [Packages](https://github.com/cloudposse/packages) - Cloud Posse installer and distribution of native apps
 - [Dev Harness](https://github.com/cloudposse/dev) - Cloud Posse Local Development Harness
-
-
 
 
 ## References


### PR DESCRIPTION
## what
- Add Terraform versions 0.15 and 1.x

## why
- Enable build and test with current versions of Terraform