### PR TITLE
set .DEFAULT_GOAL target to default

### DIFF
--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -9,6 +9,8 @@ SHELL = /bin/bash
 DEFAULT_HELP_TARGET ?= help/short
 HELP_FILTER ?= .*
 
+.DEFAULT_GOAL := default
+
 green = $(shell echo -e '\x1b[32;01m$1\x1b[0m')
 yellow = $(shell echo -e '\x1b[33;01m$1\x1b[0m')
 red = $(shell echo -e '\x1b[33;31m$1\x1b[0m')


### PR DESCRIPTION
## what
This addresses a very minor issue I experienced during first use, by explicitly setting the default goal to the `default` target, when `make` is executed with no targets specified. Please feel free to take from this what you will, address with a different change, or not at all. Thanks!

## why
Ideally, when users run `make` without any targets, it should have a predictable outcome. Without a `.DEFAULT_GOAL`, make will execute the [first target defined](https://www.gnu.org/software/make/manual/html_node/Goals.html) which can drift over time. 

For example, [#220](https://github.com/cloudposse/build-harness/pull/220/files#diff-00f59d33e76ed9182f16a8d3a84d77684cee501c3df9fb362502858623b177f3R26-R38) reordered the `default` target in `Makefile.helpers`. Unclear to me if this was intentional, or inadvertent, or what the original intent was for the default target. 

