### PR TITLE
Create a draft release rather than no release with `no-release` label

### DIFF
--- a/templates/.github/auto-release.yml
+++ b/templates/.github/auto-release.yml
@@ -17,6 +17,7 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
+    - 'no-release'
   default: 'minor'
 
 categories:

--- a/templates/.github/workflows/auto-release.yml
+++ b/templates/.github/workflows/auto-release.yml
@@ -18,9 +18,8 @@ jobs:
           github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
-        if: "!contains(steps.get-merged-pull-request.outputs.labels, 'no-release')"
         with:
-          publish: true
+          publish: ${{ !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
           prerelease: false
           config-name: auto-release.yml
         env:


### PR DESCRIPTION
## what
- When a PR is labeled `no-release`, still create a draft release

## why
- Allows you to accumulate releases via the `no-release` tag and then make a manual release out of the draft release, taking advantage of the auto-releaser's drafting capabilities. 