### PR TITLE
Update AWS CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apk --update --no-cache add \
       gettext \
       go \
       grep \
+      groff \
       jq \
       libc6-compat \
       make \
@@ -25,9 +26,9 @@ RUN apk --update --no-cache add \
     python3 -m pip install --upgrade pip setuptools wheel && \
     pip3 install --no-cache-dir \
       PyYAML==5.4.1 \
-      awscli==1.19.49 \
+      awscli==1.20.28 \
       boto==2.49.0 \
-      boto3==1.17.49 \
+      boto3==1.18.28 \
       iteration-utilities==0.11.0 \
       pre-commit \
       PyGithub==1.54.1 && \
@@ -69,7 +70,7 @@ WORKDIR /build-harness
 
 ARG PACKAGES_PREFER_HOST=true
 RUN make -s bash/lint make/lint
-RUN make -s template/deps aws/install terraform/install readme/deps
+RUN make -s template/deps readme/deps
 RUN make -s go/deps-build go/deps-dev
 
 ENTRYPOINT ["/usr/bin/make"]

--- a/modules/aws/Makefile
+++ b/modules/aws/Makefile
@@ -1,4 +1,4 @@
-export AWSCLI_VERSION ?= 1.11.185
+export AWSCLI_VERSION ?= 1.20.28
 
 WITH_AWS ?= aws-vault exec $(AWS_PROFILE) --
 


### PR DESCRIPTION
## what
- Update `aws` CLI to 1.20.28

## why
- Needed to support EKS, specifically `aws eks get-totken`