### PR TITLE
Don't use bash test syntax to test a command

### DIFF
--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -44,9 +44,8 @@ if [[ \
 	-f "/build-harness/Makefile" || -f "/$(BUILD_HARNESS_PROJECT)/Makefile" \
 ]]; then \
 	echo "[.build-harness]: In $(BUILD_HARNESS_PROJECT) docker container, skipping auto-init" ;\
-elif [[ \
-	grep -q docker /proc/1/cgroup 2>/dev/null \
-]]; then \
+elif grep -q docker /proc/1/cgroup 2>/dev/null ; \
+then \
 	echo "[.build-harness]: In unknown docker container, skipping auto-init" ;\
 elif [[ \
 	"$(BUILD_HARNESS_PATH)" != "$(BUILD_HARNESS_PATH_LOCAL)" && \


### PR DESCRIPTION
If you want to check a command return value in a bash if/else construct,
you don't surround it with bash [[ test ]] brackets - you simply run the
command and test its return value.

This removes a bunch of errors that I see on running make with
build-harness like:

```
/bin/bash: -c: line 0: conditional binary operator expected
/bin/bash: -c: line 0: syntax error near `-q'
/bin/bash: -c: line 0: `if [[ -f "/build-harness/Makefile" || -f "/build-harness/Makefile" ]]; then echo "[.build-harness]: In build-harness docker container, skipping auto-init" ; elif [[ grep -q docker /proc/1/cgroup 2>/dev/null ]]; then echo "[.build-harness]: In unknown docker container, skipping auto-init" ; elif [[ "/build/myapp/app/build-harness" != "/build/myapp/app/build-harness" && -f "/build/myapp/app/build-harness/Makefile" ]]; then echo "[.build-harness]: Using external /build/myapp/app/build-harness, skipping auto-init" ; elif [[ "/build/myapp/app/build-harness" == "/build/myapp/app/build-harness" && -f "/build/myapp/app/build-harness/Makefile" && "$(git -C '/build/myapp/app/build-harness' ls-remote 'https://github.com/cloudposse/build-harness.git' 'master' | cut -f1)" == "$(git -C '/build/myapp/app/build-harness' rev-parse HEAD)" ]]; then echo "[.build-harness]: Clone of build-harness is up-to-date, skipping auto-init" ; else curl --retry 5 --fail --silent --retry-delay 1 https://raw.githubusercontent.com/cloudposse/build-harness/master/bin/install.sh | bash -s "cloudposse" "build-harness" "master" ; fi >&2'
```

## what
* Fix incorrect syntax

## why
* Remove annoying error messages each time we run `make`

