### PR TITLE
Make 1.x the default Terraform version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN apk --update --no-cache add \
     sed -i /PATH=/d /etc/profile
 
 # Use Terraform 0.13 by default
-ARG DEFAULT_TERRAFORM_VERSION=0.13
+ARG DEFAULT_TERRAFORM_VERSION=1
 RUN update-alternatives --set terraform /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform && \
   mkdir -p /build-harness/vendor && \
   cp -p /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform /build-harness/vendor/terraform

--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,6 @@ ifndef TRANSLATE_COLON_NOTATION
 endif
 
 endif
+
+# builder/build is defined in templates/Makefile.build-harness
+build: builder/build

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -79,12 +79,16 @@ clean::
 	[ "$(BUILD_HARNESS_PATH)" == '/$(BUILD_HARNESS_PROJECT)' ] || \
 	echo rm -rf $(BUILD_HARNESS_PATH)
 
-.PHONY: build-harness/shell builder build-harness/shell/pull builder/pull
+.PHONY: build-harness/shell builder build-harness/shell/pull builder/pull builder/build
 
-build-harness/shell/pull builder/pull: BUILD_HARNESS_DOCKER_SHA_TAG ?= $(shell $(BUILD_HARNESS_DOCKER_SHA_TAG_CMD))
+build-harness/shell/pull builder/pull builder/build: BUILD_HARNESS_DOCKER_SHA_TAG ?= $(shell $(BUILD_HARNESS_DOCKER_SHA_TAG_CMD))
 build-harness/shell/pull builder/pull:
 	docker pull $(BUILD_HARNESS_DOCKER_IMAGE):$(BUILD_HARNESS_DOCKER_SHA_TAG)
 	@[[ "$(BUILD_HARNESS_DOCKER_SHA_TAG)" == "latest" ]] || docker pull $(BUILD_HARNESS_DOCKER_IMAGE):latest
+
+builder/build: export DOCKER_IMAGE_NAME = $(BUILD_HARNESS_DOCKER_IMAGE):$(BUILD_HARNESS_DOCKER_SHA_TAG)
+builder/build:
+	@$(MAKE) --no-print-directory docker/build
 
 DEFAULT_DOCKER_ENVS := AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN TERM AWS_PROFILE AWS_REGION \
 	AWS_DEFAULT_PROFILE AWS_DEFAULT_REGION


### PR DESCRIPTION
## what
- Make 1.x the default Terraform version, replacing 0.13
- Add  a `build` target to the Makefile

## why
- When running the `build-harness` Docker image manually, tools usually use the default Terraform version, and this affects things like Terraform formatting. Cloud Posse is now using Terraform 1.x on all new projects, so it is a better default.
- The plain `docker/build` `make` target does not tag the Docker image with the tag other `make` targets expect to find, which makes developing `build-harness` unnecessarily difficult. Now `make build` will build and tag the image so that other commands like `make build-harness/shell` will find the image.