### PR TITLE
Only build build-harness from the build-harness project (bug in #299)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN apk --update --no-cache add \
       yq@cloudposse && \
     sed -i /PATH=/d /etc/profile
 
-# Use Terraform 0.13 by default
+# Use Terraform 1.x by default
 ARG DEFAULT_TERRAFORM_VERSION=1
 RUN update-alternatives --set terraform /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform && \
   mkdir -p /build-harness/vendor && \

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ auto-label:
 	for module in $(MODULES); do \
 		echo "$${module%/}: $${module}**"; \
 	done > .github/$@.yml
+
+# builder/build is defined in templates/Makefile.build-harness
+build: builder/build
+
 endif
 
 # Import Makefiles into current context
@@ -54,6 +58,3 @@ ifndef TRANSLATE_COLON_NOTATION
 endif
 
 endif
-
-# builder/build is defined in templates/Makefile.build-harness
-build: builder/build


### PR DESCRIPTION
## what
- Only build build-harness from the build-harness project 
- Fix comment about default Terraform version

## why
- Bug in #299 causes Docker images to be built twice, the first time tagged with the build-harness Docker Image name and tag
- Inaccurate comment flagged in #299 but merged anyway
