### PR TITLE
switch to using terraform-1.0 instead of terraform-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,32 +7,32 @@ LABEL "com.github.actions.icon"="tool"
 LABEL "com.github.actions.color"="blue"
 
 RUN apk --update --no-cache add \
-      bash \
-      ca-certificates \
-      coreutils \
-      curl \
-      git \
-      gettext \
-      go \
-      grep \
-      groff \
-      jq \
-      libc6-compat \
-      make \
-      perl \
-      python3-dev \
-      py-pip \
-      py3-ruamel.yaml && \
-    python3 -m pip install --upgrade pip setuptools wheel && \
-    pip3 install --no-cache-dir \
-      PyYAML==5.4.1 \
-      awscli==1.20.28 \
-      boto==2.49.0 \
-      boto3==1.18.28 \
-      iteration-utilities==0.11.0 \
-      pre-commit \
-      PyGithub==1.54.1 && \
-    git config --global advice.detachedHead false
+  bash \
+  ca-certificates \
+  coreutils \
+  curl \
+  git \
+  gettext \
+  go \
+  grep \
+  groff \
+  jq \
+  libc6-compat \
+  make \
+  perl \
+  python3-dev \
+  py-pip \
+  py3-ruamel.yaml && \
+  python3 -m pip install --upgrade pip setuptools wheel && \
+  pip3 install --no-cache-dir \
+  PyYAML==5.4.1 \
+  awscli==1.20.28 \
+  boto==2.49.0 \
+  boto3==1.18.28 \
+  iteration-utilities==0.11.0 \
+  pre-commit \
+  PyGithub==1.54.1 && \
+  git config --global advice.detachedHead false
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -fsSL --retry 3 https://apk.cloudposse.com/install.sh | bash
@@ -42,22 +42,22 @@ RUN curl -fsSL --retry 3 https://apk.cloudposse.com/install.sh | bash
 ## Codefresh required additional libraries for alpine
 ## So can not be curl binary
 RUN apk --update --no-cache add \
-      chamber@cloudposse \
-      gomplate@cloudposse \
-      helm@cloudposse \
-      helmfile@cloudposse \
-      codefresh@cloudposse \
-      terraform-0.11@cloudposse terraform-0.12@cloudposse \
-      terraform-0.13@cloudposse terraform-0.14@cloudposse \
-      terraform-0.15@cloudposse terraform-1@cloudposse \
-      terraform-config-inspect@cloudposse \
-      terraform-docs@cloudposse \
-      vert@cloudposse \
-      yq@cloudposse && \
-    sed -i /PATH=/d /etc/profile
+  chamber@cloudposse \
+  gomplate@cloudposse \
+  helm@cloudposse \
+  helmfile@cloudposse \
+  codefresh@cloudposse \
+  terraform-0.11@cloudposse terraform-0.12@cloudposse \
+  terraform-0.13@cloudposse terraform-0.14@cloudposse \
+  terraform-0.15@cloudposse terraform-1.0@cloudposse \
+  terraform-config-inspect@cloudposse \
+  terraform-docs@cloudposse \
+  vert@cloudposse \
+  yq@cloudposse && \
+  sed -i /PATH=/d /etc/profile
 
-# Use Terraform 1.x by default
-ARG DEFAULT_TERRAFORM_VERSION=1
+# Use Terraform 1.0.x by default
+ARG DEFAULT_TERRAFORM_VERSION=1.0
 RUN update-alternatives --set terraform /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform && \
   mkdir -p /build-harness/vendor && \
   cp -p /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform /build-harness/vendor/terraform

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -28,7 +28,7 @@ RUN curl -fsSL --retry 3 https://apk.cloudposse.com/install.sh | bash
 RUN apk --no-cache add \
       gomplate@cloudposse \
       terraform-0.12@cloudposse terraform-0.13@cloudposse terraform-0.14@cloudposse \
-      terraform-0.15@cloudposse terraform-1@cloudposse \
+      terraform-0.15@cloudposse terraform-1.0@cloudposse \
       terraform-config-inspect@cloudposse \
       terraform-docs@cloudposse \
       vert@cloudposse
@@ -38,8 +38,8 @@ RUN sed -i /PATH=/d /etc/profile
 # Use Terraform 0.13 by default
 ARG DEFAULT_TERRAFORM_VERSION=0.13
 RUN update-alternatives --set terraform /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform && \
-  mkdir -p /build-harness/vendor && \
-  ln -s /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform /build-harness/vendor/terraform
+      mkdir -p /build-harness/vendor && \
+      ln -s /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform /build-harness/vendor/terraform
 
 COPY ./ /build-harness/
 


### PR DESCRIPTION
## what
-  Switch to using the terraform-1.0 package rather than the terraform-1 package

## why

- Some scripts expect Terraform to be installed in a directory named with major.minor and the previous terraform-1 installed to major only.

## references

- This should not be merged until after cloudposse/packages#1848 is merged

