### PR TITLE
 Finish #299, default to Terraform v1 in builder-slim

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -9,10 +9,15 @@ jobs:
   semver:
     runs-on: ubuntu-latest
     steps:
+    # Get PR from merged commit to master
+    - uses: actions-ecosystem/action-get-merged-pull-request@v1
+      id: get-merged-pull-request
+      with:
+        github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
     # Drafts your next Release notes as Pull Requests are merged into "master"
     - uses: release-drafter/release-drafter@v5
       with:
-        publish: true
+        publish: ${{ !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
         prerelease: false
         config-name: auto-release.yml
       env:

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -35,11 +35,18 @@ RUN apk --no-cache add \
 
 RUN sed -i /PATH=/d /etc/profile
 
-# Use Terraform 0.13 by default
-ARG DEFAULT_TERRAFORM_VERSION=0.13
+# Use Terraform 1 by default
+ARG DEFAULT_TERRAFORM_VERSION=1
 RUN update-alternatives --set terraform /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform && \
   mkdir -p /build-harness/vendor && \
   ln -s /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform /build-harness/vendor/terraform
+
+# Patch for old Makefiles that expect a directory like x.x from the 0.x days.
+# Fortunately, they only look for the current version, so we only need links
+# for the current major version.
+RUN v=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version' | cut -d. -f1-2) && \
+    major=${v%%\.*} && n=$(( ${v##*\.} + 1 )) && \
+    for (( x=0; x <= $n; x++ )); do ln -s /usr/local/terraform/{${major},${major}.${x}}; done
 
 COPY ./ /build-harness/
 

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -44,9 +44,7 @@ if [[ \
 	-f "/build-harness/Makefile" || -f "/$(BUILD_HARNESS_PROJECT)/Makefile" \
 ]]; then \
 	echo "[.build-harness]: In $(BUILD_HARNESS_PROJECT) docker container, skipping auto-init" ;\
-elif [[ \
-	grep -q docker /proc/1/cgroup 2>/dev/null \
-]]; then \
+elif grep -q docker /proc/1/cgroup 2>/dev/null; then \
 	echo "[.build-harness]: In unknown docker container, skipping auto-init" ;\
 elif [[ \
 	"$(BUILD_HARNESS_PATH)" != "$(BUILD_HARNESS_PATH_LOCAL)" && \


### PR DESCRIPTION
## what

- Finish #299, default to Terraform v1 in builder-slim
- Symlink current Terraform `major`.`minor` directories to `major`
- Fix bash test. Thanks @tevansuk
- Support `no-release` label

## why

* #299 Made Terraform 1.x for the `builder` Docker image but neglected to update the `builder-slim` Docker image.
* Some deployed Makefiles expect Terraform to be installed in a directory named with `major`.`minor` due to pre-production versions using semver `0.major` versioning. With Terraform production version, the major version is back to its rightful place, so we only need `major`, but the old Makefile are installed in hundreds of Terraform modules, so we need some backward support for them.
* Bad syntax in Makefile causes errors during auto-init.
* Sometimes we want to merge changes (such as for PR #298) without triggering a release, for example to bundle several PRs into a single release.

## references

* Incorporates and closes #298. Thank you @tevansuk
