### PR TITLE
Update validate codeowners, install auto-readme

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Lint Code Base
-        uses: docker://github/super-linter:v3
+        uses: github/super-linter/slim@v4
         env:
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,3 +29,6 @@ jobs:
         uses: github/super-linter/slim@v4
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_NATURAL_LANGUAGE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.6.0
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"
       with:
@@ -18,7 +18,7 @@ jobs:
         checks: "syntax,owners,duppatterns"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.6.0
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"
       with:

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -15,12 +15,12 @@ red = $(shell echo -e '\x1b[33;31m$1\x1b[0m')
 
 # Ensures that a variable is defined and non-empty
 define assert-set
-  @$(if $($(1)),,$(error $(1) not defined in $(@)))
+	@$(if $($(1)),,$(error $(1) not defined in $(@)))
 endef
 
 # Ensures that a variable is undefined
 define assert-unset
-  @$(if $($1),$(error $(1) should not be defined in $(@)),)
+	@$(if $($1),$(error $(1) should not be defined in $(@)),)
 endef
 
 test/assert-set:
@@ -55,14 +55,14 @@ help/short:
 # Generate help output from MAKEFILE_LIST
 help/generate:
 	@awk '/^[-a-zA-Z_0-9%:\\\.\/]+:/ { \
-	  helpMessage = match(lastLine, /^## (.*)/); \
-	  if (helpMessage) { \
-	    helpCommand = $$1; \
-	    helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
-      gsub("\\\\", "", helpCommand); \
-      gsub(":+$$", "", helpCommand); \
-	    printf "  \x1b[32;01m%-35s\x1b[0m %s\n", helpCommand, helpMessage; \
-	  } \
+		helpMessage = match(lastLine, /^## (.*)/); \
+		if (helpMessage) { \
+			helpCommand = $$1; \
+			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
+			gsub("\\\\", "", helpCommand); \
+			gsub(":+$$", "", helpCommand); \
+			printf "	\x1b[32;01m%-35s\x1b[0m %s\n", helpCommand, helpMessage; \
+		} \
 	} \
 	{ lastLine = $$0 }' $(MAKEFILE_LIST) | sort -u
 	@printf "\n"

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -54,7 +54,7 @@ help/short:
 
 # Generate help output from MAKEFILE_LIST
 help/generate:
-	@awk '/^[a-zA-Z\_0-9%:\\\/-]+:/ { \
+	@awk '/^[-a-zA-Z_0-9%:\\\.\/]+:/ { \
 	  helpMessage = match(lastLine, /^## (.*)/); \
 	  if (helpMessage) { \
 	    helpCommand = $$1; \

--- a/Makefile.helpers
+++ b/Makefile.helpers
@@ -61,7 +61,7 @@ help/generate:
 			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
 			gsub("\\\\", "", helpCommand); \
 			gsub(":+$$", "", helpCommand); \
-			printf "	\x1b[32;01m%-35s\x1b[0m %s\n", helpCommand, helpMessage; \
+			printf "  \x1b[32;01m%-35s\x1b[0m %s\n", helpCommand, helpMessage; \
 		} \
 	} \
 	{ lastLine = $$0 }' $(MAKEFILE_LIST) | sort -u

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Available targets:
   docker/image/push                   Push $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
   docker/login                        Login into docker hub
   docs/copyright-add                  Add copyright headers to source code
+  docs/targets.md                     Update `docs/targets.md` from `make help`
+  docs/terraform.md                   Update `docs/terraform.md` from `terraform-docs`
   geodesic/deploy                     Run a Jenkins Job to Deploy $(APP) with $(CANONICAL_TAG)
   git/aliases-update                  Update git aliases
   git/export                          Export git vars

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2016-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2016-2022 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ Available targets:
   template/build                      Create $OUT file by building it from $IN template file
   template/deps                       Install dependencies
   terraform/bump-tf-12-min-version    Rewrite versions.tf to bump modules with minimum core version of '0.12.x' to '>= 0.12.26'
-  terraform/get-modules               Ensure all modules can be fetched
-  terraform/get-plugins               Ensure all plugins can be fetched
+  terraform/get-modules               (Obsolete) Ensure all modules can be fetched
+  terraform/get-plugins               (Obsolete) Ensure all plugins can be fetched
   terraform/install                   Install terraform
   terraform/lint                      Lint check Terraform
   terraform/loosen-constraints        and convert "~>" constraints to ">=".

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ At the top of your `Makefile` add, the following...
 -include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
 ```
 
-This will download a `Makefile` called `.build-harness` and include it at run-time. We recommend adding the `.build-harness` file to your `.gitignore`.
+This will download a `Makefile` called `.build-harness` and include it at run time. We recommend adding the `.build-harness` file to your `.gitignore`.
 
 This automatically exposes many new targets that you can leverage throughout your build & CI/CD process.
 

--- a/README.yaml
+++ b/README.yaml
@@ -74,7 +74,7 @@ usage: |-
   -include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
   ```
 
-  This will download a `Makefile` called `.build-harness` and include it at run-time. We recommend adding the `.build-harness` file to your `.gitignore`.
+  This will download a `Makefile` called `.build-harness` and include it at run time. We recommend adding the `.build-harness` file to your `.gitignore`.
 
   This automatically exposes many new targets that you can leverage throughout your build & CI/CD process.
 

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -117,8 +117,8 @@ Available targets:
   template/build                      Create $OUT file by building it from $IN template file
   template/deps                       Install dependencies
   terraform/bump-tf-12-min-version    Rewrite versions.tf to bump modules with minimum core version of '0.12.x' to '>= 0.12.26'
-  terraform/get-modules               Ensure all modules can be fetched
-  terraform/get-plugins               Ensure all plugins can be fetched
+  terraform/get-modules               (Obsolete) Ensure all modules can be fetched
+  terraform/get-plugins               (Obsolete) Ensure all plugins can be fetched
   terraform/install                   Install terraform
   terraform/lint                      Lint check Terraform
   terraform/loosen-constraints        and convert "~>" constraints to ">=".

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -43,6 +43,8 @@ Available targets:
   docker/image/push                   Push $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
   docker/login                        Login into docker hub
   docs/copyright-add                  Add copyright headers to source code
+  docs/targets.md                     Update `docs/targets.md` from `make help`
+  docs/terraform.md                   Update `docs/terraform.md` from `terraform-docs`
   geodesic/deploy                     Run a Jenkins Job to Deploy $(APP) with $(CANONICAL_TAG)
   git/aliases-update                  Update git aliases
   git/export                          Export git vars

--- a/modules/github/Makefile.init
+++ b/modules/github/Makefile.init
@@ -13,6 +13,7 @@ GITHUB_TEMPLATES = \
 GITHUB_TERRAFORM_TEMPLATES = .github/workflows/chatops.yml \
 	.github/workflows/auto-context.yml \
 	.github/workflows/auto-format.yml \
+	.github/workflows/auto-readme.yml \
 	.github/mergify.yml \
 	.github/renovate.json
 

--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -16,7 +16,7 @@ terraform/install:
 
 ## (Obsolete) Ensure all plugins can be fetched
 terraform/get-plugins:
-	@$echo terraform -get-plugins no longer supported
+	@echo terraform -get-plugins no longer supported
 
 ## (Obsolete) Ensure all modules can be fetched
 terraform/get-modules:

--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -14,11 +14,11 @@ terraform/install:
 		)
 	$(TERRAFORM) version
 
-## Ensure all plugins can be fetched
+## (Obsolete) Ensure all plugins can be fetched
 terraform/get-plugins:
 	@$echo terraform -get-plugins no longer supported
 
-## Ensure all modules can be fetched
+## (Obsolete) Ensure all modules can be fetched
 terraform/get-modules:
 	@$(TERRAFORM) init -get -backend=false -input=false >/dev/null
 

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -72,8 +72,8 @@ init::
 .PHONY : clean
 ## Clean build-harness
 clean::
-	if [ -d "$(BUILD_HARNESS_PATH)" ]; then \
-	  if [ -d build-harness ] && [ $$(stat -f %i "$(BUILD_HARNESS_PATH)") == $$(stat -f %i build-harness) ]; then \
+	@if [ -d "$(BUILD_HARNESS_PATH)" ]; then \
+	  if [ -d build-harness ] && [ $$(ls -di "$(BUILD_HARNESS_PATH)" | cut -f 1 -d' ') == $$(ls -di build-harness | cut -f 1 -d' ') ]; then \
 	    rm -rf build-harness; \
 	  else \
 	    echo Not removing build harness from "$(BUILD_HARNESS_PATH)" because it appears to be shared.; \

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -73,13 +73,13 @@ init::
 ## Clean build-harness
 clean::
 	@if [ -d "$(BUILD_HARNESS_PATH)" ]; then \
-	  if [ -d build-harness ] && [ $$(ls -di "$(BUILD_HARNESS_PATH)" | cut -f 1 -d' ') == $$(ls -di build-harness | cut -f 1 -d' ') ]; then \
-	    rm -rf build-harness; \
-	  else \
-	    echo Not removing build harness from "$(BUILD_HARNESS_PATH)" because it appears to be shared.; \
-	    echo If you are sure you want to delete it, run: ; \
-	    echo '   rm -rf "$(BUILD_HARNESS_PATH)"'; \
-	  fi; \
+		if [ -d build-harness ] && [ $$(ls -di "$(BUILD_HARNESS_PATH)" | cut -f 1 -d' ') == $$(ls -di build-harness | cut -f 1 -d' ') ]; then \
+			rm -rf build-harness; \
+		else \
+			echo Not removing build harness from "$(BUILD_HARNESS_PATH)" because it appears to be shared.; \
+			echo If you are sure you want to delete it, run: ; \
+			echo '   rm -rf "$(BUILD_HARNESS_PATH)"'; \
+		fi; \
 	fi
 
 .PHONY: build-harness/shell builder build-harness/shell/pull builder/pull builder/build


### PR DESCRIPTION
## what
- Mark Terraform `get-plugins` and `get-modules` as Obsolete
- Automatically install `auto-readme.yml` workflow in Terraform modules
- Update `codeowners-validator` from v0.5.0 -> v0.6.0
- Fix `make terraform/get-plugins` and `make clean`,  thanks to @jbouse
- Fix `make/help` and `make help/all`, thanks to @slewis-bd
- Update `super-linter` to v4


## why
- No longer supported by Terraform
- Cause changes to README template to propagate to all modules without creating a new release
- Multiple bug fixes in `codeowners-validator`
- Closes #305, supersedes and closes #306
- Closes #307
- Super Linter v3 has known issues and security flaws and is considered obsolete

## references
- https://github.com/mszostok/codeowners-validator/releases/tag/v0.6.0
- https://github.com/github/super-linter/issues/2253
