### PR TITLE
GitHub auto update

### DIFF
--- a/.github/.github-update-disabled
+++ b/.github/.github-update-disabled
@@ -1,0 +1,3 @@
+This presence of a .github/.github-update-disabled file
+prevents `make github/update` from making any changes.
+The contents of the file are ignored.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,5 +30,6 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_DOCKERFILE_HADOLINT: false
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
-    - uses: mszostok/codeowners-validator@v0.7.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"
       with:
@@ -21,7 +21,7 @@ jobs:
         owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.7.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"
       with:

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,5 +1,7 @@
 name: Validate Codeowners
 on:
+  workflow_dispatch:
+
   pull_request:
 
 jobs:
@@ -8,7 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
-    - uses: mszostok/codeowners-validator@v0.6.0
+    - uses: mszostok/codeowners-validator@v0.7.0
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"
       with:
@@ -16,10 +18,12 @@ jobs:
         # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
         #   checks: "files,syntax,owners,duppatterns"
         checks: "syntax,owners,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.6.0
+    - uses: mszostok/codeowners-validator@v0.7.0
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"
       with:
         checks: "syntax,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.11-alpine3.13
+FROM golang:1.17.7-alpine3.15
 LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
 
 LABEL "com.github.actions.name"="Build Harness"
@@ -26,12 +26,12 @@ RUN apk --update --no-cache add \
     python3 -m pip install --upgrade pip setuptools wheel && \
     pip3 install --no-cache-dir \
       PyYAML==5.4.1 \
-      awscli==1.20.28 \
+      awscli==1.22.56 \
       boto==2.49.0 \
-      boto3==1.18.28 \
+      boto3==1.21.1 \
       iteration-utilities==0.11.0 \
       pre-commit \
-      PyGithub==1.54.1 && \
+      PyGithub==1.55 && \
     git config --global advice.detachedHead false
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN apk --update --no-cache add \
       perl \
       python3-dev \
       py-pip \
-      py3-ruamel.yaml && \
+      py3-ruamel.yaml \
+      py3-cffi && \
     python3 -m pip install --upgrade pip setuptools wheel && \
     pip3 install --no-cache-dir \
       PyYAML==5.4.1 \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.15
 LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
 
 LABEL "com.github.actions.name"="Build Harness"

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017-2019 Cloud Posse, LLC
+   Copyright 2017-2022 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/modules/github/Makefile.init
+++ b/modules/github/Makefile.init
@@ -17,16 +17,21 @@ GITHUB_TERRAFORM_TEMPLATES = .github/workflows/chatops.yml \
 	.github/mergify.yml \
 	.github/renovate.json
 
+# Create a file (contents unimportant) with this name
+# to prevent pr/auto-format etc. from updating the GitHub templates.
+GITHUB_UPDATE_DISABLE_SENTINEL := .github/.github-update-disabled
 
 $(GITHUB_TEMPLATES): $(addprefix $(BUILD_HARNESS_PATH)/templates/, $(GITHUB_TEMPLATES))
-	mkdir -p $(dir $@)
-	cp $(BUILD_HARNESS_PATH)/templates/$@ $@
-	git ls-files --error-unmatch $@ 2>/dev/null || git add $@
+	@mkdir -p $(dir $@)
+	@cp $(BUILD_HARNESS_PATH)/templates/$@ $@
+	@git ls-files --error-unmatch $@ >/dev/null 2>&1 || { git add $@; echo "# github/update: Added $@"; }
+	@for file in $$(git diff --name-only $@); do echo "# github/update: Updated $$file"; done
 
 $(GITHUB_TERRAFORM_TEMPLATES): $(addprefix $(BUILD_HARNESS_PATH)/templates/terraform/, $(GITHUB_TERRAFORM_TEMPLATES))
-	mkdir -p $(dir $@)
-	cp $(BUILD_HARNESS_PATH)/templates/terraform/$@ $@
-	git ls-files --error-unmatch $@ 2>/dev/null || git add $@
+	@mkdir -p $(dir $@)
+	@cp $(BUILD_HARNESS_PATH)/templates/terraform/$@ $@
+	@git ls-files --error-unmatch $@ >/dev/null 2>&1 || { git add $@; echo "# github/update: Added " $@; }
+	@for file in $$(git diff --name-only $@); do echo "# github/update: Updated $$file"; done
 
 # Update context.tf if it is in place. Leave it in directory
 # if it did not previously exist, but do not add it to git
@@ -38,6 +43,19 @@ github/init/context.tf:
 	fi
 	find . -xdev -mindepth 2 -name context.tf -exec cp -p context.tf {} \;
 
-.PHONY: $(GITHUB_TEMPLATES) $(GITHUB_TERRAFORM_TEMPLATES) github/init/context.tf
+.PHONY: $(GITHUB_TEMPLATES) $(GITHUB_TERRAFORM_TEMPLATES) github/init/context.tf github/init github/update
 
 github/init: $(GITHUB_TEMPLATES) $(if $(wildcard *.tf),$(GITHUB_TERRAFORM_TEMPLATES) github/init/context.tf)
+
+ifeq (,$(wildcard $(GITHUB_UPDATE_DISABLE_SENTINEL)))
+
+# Unless the sentinel file is present, update all the GitHub templates.
+# Do not update context.tf via github/update. That should be updated separately and explicitly.
+github/update: $(GITHUB_TEMPLATES) $(if $(wildcard *.tf),$(GITHUB_TERRAFORM_TEMPLATES))
+	@printf "\n** GitHub workflows updated **\n\n"
+
+else
+github/update:
+	@printf "\n** Auto-update of GitHub workflows disabled by presence of %s **\n\n"  "$(GITHUB_UPDATE_DISABLE_SENTINEL)"
+
+endif

--- a/templates/.github/workflows/validate-codeowners.yml
+++ b/templates/.github/workflows/validate-codeowners.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
-    - uses: mszostok/codeowners-validator@v0.7.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"
       with:
@@ -21,7 +21,7 @@ jobs:
         owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.7.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"
       with:

--- a/templates/.github/workflows/validate-codeowners.yml
+++ b/templates/.github/workflows/validate-codeowners.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.0
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"
       with:
@@ -18,10 +18,12 @@ jobs:
         # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
         #   checks: "files,syntax,owners,duppatterns"
         checks: "syntax,owners,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.0
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"
       with:
         checks: "syntax,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -73,7 +73,8 @@ init::
 ## Clean build-harness
 clean::
 	@if [ -d "$(BUILD_HARNESS_PATH)" ]; then \
-		if [ -d build-harness ] && [ $$(ls -di "$(BUILD_HARNESS_PATH)" | cut -f 1 -d' ') == $$(ls -di build-harness | cut -f 1 -d' ') ]; then \
+		if [ -d build-harness ] && [ "$(BUILD_HARNESS_PATH)" -ef build-harness ]; then \
+			echo rm -rf build-harness; \
 			rm -rf build-harness; \
 		else \
 			echo Not removing build harness from "$(BUILD_HARNESS_PATH)" because it appears to be shared.; \
@@ -105,12 +106,12 @@ build-harness/shell builder tester: MOUNT_HOME ?= $(shell [ -d "$$HOME" ] && pri
 build-harness/shell builder tester: TARGETS ?= $(TARGET)
 build-harness/shell builder tester: ARGS := $(if $(TARGETS),$(TARGETS),-l || true)
 build-harness/shell builder tester: ENTRYPOINT := $(if $(TARGETS),/usr/bin/make,/bin/bash)
-build-harness/shell builder pr/pre-commit: RUNNER_DOCKER_TAG ?= $(shell $(BUILD_HARNESS_DOCKER_SHA_TAG_CMD))
-build-harness/shell builder pr/pre-commit: RUNNER_DOCKER_IMAGE ?= $(BUILD_HARNESS_DOCKER_IMAGE)
+build-harness/shell builder pr/pre-commit pr/readme pr/github-update: RUNNER_DOCKER_TAG ?= $(shell $(BUILD_HARNESS_DOCKER_SHA_TAG_CMD))
+build-harness/shell builder pr/pre-commit pr/readme pr/github-update: RUNNER_DOCKER_IMAGE ?= $(BUILD_HARNESS_DOCKER_IMAGE)
 build-harness/shell builder: build-harness/runner
 	@exit 0
 
-.PHONY: build-harness/shell-slim builder-slim pr/auto-format pr/auto-format/host pr/readme pr/readme/host pr/pre-commit tf14-upgrade
+.PHONY: build-harness/shell-slim builder-slim pr/auto-format pr/auto-format/host pr/readme pr/readme/host pr/pre-commit pr/github-update pr/github-update/host tf14-upgrade
 
 build-harness/shell-slim builder-slim pr/auto-format pr/readme tf14-upgrade: RUNNER_DOCKER_IMAGE ?= $(BUILD_HARNESS_DOCKER_IMAGE)
 
@@ -124,12 +125,13 @@ build-harness/shell-slim builder-slim: ARGS := $(if $(TARGETS),$(TARGETS),-l || 
 build-harness/shell-slim builder-slim: ENTRYPOINT := $(if $(TARGETS),/usr/bin/make,/bin/bash)
 build-harness/shell-slim builder-slim: build-harness/runner
 
-pr/auto-format pr/readme pr/pre-commit tf14-upgrade : ENTRYPOINT := /usr/bin/make
+pr/auto-format pr/readme pr/pre-commit pr/github-update tf14-upgrade : ENTRYPOINT := /usr/bin/make
 
-pr/auto-format pr/auto-format/host: ARGS := terraform/fmt readme
+pr/auto-format pr/auto-format/host: ARGS := github/update terraform/fmt readme
 pr/readme pr/readme/host: ARGS := readme/deps readme
-pr/auto-format pr/readme: build-harness/runner
-pr/auto-format/host pr/readme/host:
+pr/github-update pr/github-update/host: ARGS := github/update
+pr/auto-format pr/readme pr/github-update: build-harness/runner
+pr/auto-format/host pr/readme/host pr/github-update/host:
 	$(MAKE) $(ARGS)
 
 pr/pre-commit: ARGS := pre-commit/run

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -83,15 +83,20 @@ clean::
 		fi; \
 	fi
 
-.PHONY: build-harness/shell builder build-harness/shell/pull builder/pull builder/build
+.PHONY: build-harness/shell builder build-harness/shell/pull builder/pull builder/build builder-slim/build
 
-build-harness/shell/pull builder/pull builder/build: BUILD_HARNESS_DOCKER_SHA_TAG ?= $(shell $(BUILD_HARNESS_DOCKER_SHA_TAG_CMD))
+build-harness/shell/pull builder/pull builder/build builder-slim/build: BUILD_HARNESS_DOCKER_SHA_TAG ?= $(shell $(BUILD_HARNESS_DOCKER_SHA_TAG_CMD))
 build-harness/shell/pull builder/pull:
 	docker pull $(BUILD_HARNESS_DOCKER_IMAGE):$(BUILD_HARNESS_DOCKER_SHA_TAG)
 	@[[ "$(BUILD_HARNESS_DOCKER_SHA_TAG)" == "latest" ]] || docker pull $(BUILD_HARNESS_DOCKER_IMAGE):latest
 
 builder/build: export DOCKER_IMAGE_NAME = $(BUILD_HARNESS_DOCKER_IMAGE):$(BUILD_HARNESS_DOCKER_SHA_TAG)
 builder/build:
+	@$(MAKE) --no-print-directory docker/build
+
+builder-slim/build: export DOCKER_IMAGE_NAME = $(BUILD_HARNESS_DOCKER_IMAGE):slim-$(BUILD_HARNESS_DOCKER_SHA_TAG)
+builder-slim/build: export DOCKER_FILE := Dockerfile.slim
+builder-slim/build:
 	@$(MAKE) --no-print-directory docker/build
 
 DEFAULT_DOCKER_ENVS := AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN TERM AWS_PROFILE AWS_REGION \


### PR DESCRIPTION
## what
- Update GitHub workflows as part of make pr/auto-format
- Update `codeowners-validator` to current version 0.7.1
- Update Go 1.15.11 -> 1.17.7, Alpine 3.13 -> 3.15

## why
- Keep modules up-to-date without triggering massive waves of PRs that require high-level approvals
- Version 0.5.0 stopped working
- Security fixes