### PR TITLE
Auto-readme workflow fix: name of default branch rather than hard coding it

### DIFF
--- a/templates/terraform/.github/workflows/auto-readme.yml
+++ b/templates/terraform/.github/workflows/auto-readme.yml
@@ -1,5 +1,7 @@
 name: "auto-readme"
 on:
+  workflow_dispatch:
+
   schedule:
   # Example of job definition:
   # .---------------- minute (0 - 59)
@@ -15,21 +17,35 @@ on:
 
 jobs:
   update:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Find default branch name
+      id: defaultBranch
+      shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+        printf "::set-output name=defaultBranch::%s\n" "${default_branch}"
+        printf "defaultBranchRef.name=%s\n" "${default_branch}"
 
     - name: Update readme
       shell: bash
       id: update
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        DEF: "${{ steps.defaultBranch.outputs.defaultBranch }}"
       run: |
         make init
         make readme/build
         # Ignore changes if they are only whitespace
-        git diff --ignore-all-space --ignore-blank-lines --quiet README.md && { git restore README.md; echo Ignoring whitespace-only changes in README; }
+        if ! git diff --quiet README.md && git diff --ignore-all-space --ignore-blank-lines --quiet README.md; then
+          git restore README.md
+          echo Ignoring whitespace-only changes in README
+        fi
 
     - name: Create Pull Request
       # This action will not create or change a pull request if there are no changes to make.
@@ -47,7 +63,7 @@ jobs:
           To have most recent changes of README.md and doc from origin templates
 
         branch: auto-update/readme
-        base: main
+        base: ${{ steps.defaultBranch.outputs.defaultBranch }}
         delete-branch: true
         labels: |
           auto-update


### PR DESCRIPTION
## what
- Fix `auto-readme` workflow to detect the name of the default branch rather than rely on hard coded `main`
- Only output the message "Ignoring whitespace-only changes in README" when, in fact, there are changes to ignore

## why
- Most of our repos still use `master` for the default branch, but some use `main` and we need the right target for the PR this workflow creates
- It was confusing to see that message when there were, in fact, no changes at all