### PR TITLE
GitHub action updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.7-alpine3.15
+FROM golang:1.17.9-alpine3.15
 LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
 
 LABEL "com.github.actions.name"="Build Harness"

--- a/modules/github/Makefile.init
+++ b/modules/github/Makefile.init
@@ -43,7 +43,7 @@ github/init/context.tf:
 	fi
 	find . -xdev -mindepth 2 -name context.tf -exec cp -p context.tf {} \;
 
-.PHONY: $(GITHUB_TEMPLATES) $(GITHUB_TERRAFORM_TEMPLATES) github/init/context.tf github/init github/update
+.PHONY: $(GITHUB_TEMPLATES) $(GITHUB_TERRAFORM_TEMPLATES) github/init/context.tf github/init github/update github/update/start
 
 github/init: $(GITHUB_TEMPLATES) $(if $(wildcard *.tf),$(GITHUB_TERRAFORM_TEMPLATES) github/init/context.tf)
 
@@ -51,7 +51,7 @@ ifeq (,$(wildcard $(GITHUB_UPDATE_DISABLE_SENTINEL)))
 
 # Unless the sentinel file is present, update all the GitHub templates.
 # Do not update context.tf via github/update. That should be updated separately and explicitly.
-github/update: $(GITHUB_TEMPLATES) $(if $(wildcard *.tf),$(GITHUB_TERRAFORM_TEMPLATES))
+github/update: github/update/start $(GITHUB_TEMPLATES) $(if $(wildcard *.tf),$(GITHUB_TERRAFORM_TEMPLATES))
 	@printf "\n** GitHub workflows updated **\n\n"
 
 else
@@ -59,3 +59,6 @@ github/update:
 	@printf "\n** Auto-update of GitHub workflows disabled by presence of %s **\n\n"  "$(GITHUB_UPDATE_DISABLE_SENTINEL)"
 
 endif
+
+github/update/start:
+	@printf "\n** GitHub workflows update started **\n\n"

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -83,6 +83,12 @@ clean::
 		fi; \
 	fi
 
+.PHONY: safe-directory
+
+# Workaround for https://github.com/actions/checkout/issues/766
+safe-directory:
+	[[ -z "$$GITHUB_WORKSPACE" ]] || git config --global --add safe.directory "$$GITHUB_WORKSPACE"
+
 .PHONY: build-harness/shell builder build-harness/shell/pull builder/pull builder/build builder-slim/build
 
 build-harness/shell/pull builder/pull builder/build builder-slim/build: BUILD_HARNESS_DOCKER_SHA_TAG ?= $(shell $(BUILD_HARNESS_DOCKER_SHA_TAG_CMD))
@@ -136,7 +142,7 @@ pr/auto-format pr/auto-format/host: ARGS := github/update terraform/fmt readme
 pr/readme pr/readme/host: ARGS := readme/deps readme
 pr/github-update pr/github-update/host: ARGS := github/update
 pr/auto-format pr/readme pr/github-update: build-harness/runner
-pr/auto-format/host pr/readme/host pr/github-update/host:
+pr/auto-format/host pr/readme/host pr/github-update/host: safe-directory
 	$(MAKE) $(ARGS)
 
 pr/pre-commit: ARGS := pre-commit/run


### PR DESCRIPTION
## what
- Possible workaround for https://github.com/actions/checkout/issues/766
- Additional logging when updating GitHub action workflows
- Update `go` 1.17.7 -> 1.17.9

## why
- Fix breaking `auto-format` in Cloud Posse Terraform repos
- More readable output
- Security fixes

