### PR TITLE
Better handling of git "safe.directory"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,7 @@
 name: "docker"
 on:
+  workflow_dispatch:
+
   pull_request:
     types: [opened, synchronize, reopened]
   release:

--- a/README.md
+++ b/README.md
@@ -35,9 +35,57 @@ It's designed to work with CI/CD systems such as GitHub Actions, Codefresh, Trav
 
 GitHub announced that the [`git.io` redirector service is shutting down on 2022-04-29](https://github.blog/changelog/2022-04-25-git-io-deprecation/). This means all references to `git.io/build-harness` will stop working.
 
+We have acquired `cloudposse.tools` to mitigate this. Update all references of `git.io/build-harness` with `cloudposse.tools/build-harness`.
+Critical references are in Makefiles, and there are also important references in README files that describe Makefiles.
+
 We have acquired `cloudposse.tools` to mitigate this. Update all references of `git.io/build-harness` with `cloudposse.tools/build-harness`
 
-Use the following command to replace all occurrences:
+## Automating the update process
+
+In all cases, these commands are intended to be run from a directory at the top of the directory tree 
+under which all your potentially affected code resides. Usually either the top-level directory of a single `git` repo
+or a `src` (or similar) directory under which you have all your `git` repos (directly or in subdirectories).
+
+### Finding affected files
+
+Use the following command to find all occurrences in all directories recursively:
+```
+grep -l "git\.io/build-harness" -R .
+```
+Note that the above command can reach very deeply, such as into Terraform modules you have downloaded. You may want to impose some limits.
+If you run from the top level of a `git` repo, where there is a `Makefile` and a `Dockerfile`, you can reduce that to
+```
+grep -l "git\.io/build-harness" *
+```
+If you have a lot of Cloud Posse projects under a single directory, then you might try
+```
+grep -l "git\.io/build-harness" * */*
+```
+or for full depth below the current directory
+```
+find . \( -name .terraform -prune -type f \)  -o \( -name build-harness -prune -type f \) -o \( -name 'Makefile*' -o -name 'README*' \)
+```
+
+### Updating the affected files
+
+Once you are happy with the command to generate the list of files to update, update the files by inserting that command into this command template:
+```
+sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(<command to list files>)
+```
+
+#### Examples
+
+The quickest update will be if you only have a single project to update, in which case you can `cd` into the project root directory and
+```
+sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" *)
+```
+
+If you have multiple projects to update and want to be thorough, then this is probably best:
+```
+sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(find . \( -name .terraform -prune -type f \)  -o \( -name build-harness -prune -type f \) -o \( -name 'Makefile*' -o -name 'README*' \) )
+```
+
+This is the most thorough, but probably overkill for most people:
 ```
 sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" -R .)
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ GitHub announced that the [`git.io` redirector service is shutting down on 2022-
 
 We have acquired `cloudposse.tools` to mitigate this. Update all references of `git.io/build-harness` with `cloudposse.tools/build-harness`
 
-Use the following command to replace all occurances:
+Use the following command to replace all occurrences:
 ```
 sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" -R .)
 ```

--- a/README.yaml
+++ b/README.yaml
@@ -67,7 +67,7 @@ description: |-
   
   We have acquired `cloudposse.tools` to mitigate this. Update all references of `git.io/build-harness` with `cloudposse.tools/build-harness`
 
-  Use the following command to replace all occurances:
+  Use the following command to replace all occurrences:
   ```
   sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" -R .)
   ```

--- a/README.yaml
+++ b/README.yaml
@@ -65,13 +65,60 @@ description: |-
 
   GitHub announced that the [`git.io` redirector service is shutting down on 2022-04-29](https://github.blog/changelog/2022-04-25-git-io-deprecation/). This means all references to `git.io/build-harness` will stop working.
   
+  We have acquired `cloudposse.tools` to mitigate this. Update all references of `git.io/build-harness` with `cloudposse.tools/build-harness`.
+  Critical references are in Makefiles, and there are also important references in README files that describe Makefiles.
+  
   We have acquired `cloudposse.tools` to mitigate this. Update all references of `git.io/build-harness` with `cloudposse.tools/build-harness`
 
-  Use the following command to replace all occurrences:
+  ## Automating the update process
+  
+  In all cases, these commands are intended to be run from a directory at the top of the directory tree 
+  under which all your potentially affected code resides. Usually either the top-level directory of a single `git` repo
+  or a `src` (or similar) directory under which you have all your `git` repos (directly or in subdirectories).
+
+  ### Finding affected files
+
+  Use the following command to find all occurrences in all directories recursively:
+  ```
+  grep -l "git\.io/build-harness" -R .
+  ```
+  Note that the above command can reach very deeply, such as into Terraform modules you have downloaded. You may want to impose some limits.
+  If you run from the top level of a `git` repo, where there is a `Makefile` and a `Dockerfile`, you can reduce that to
+  ```
+  grep -l "git\.io/build-harness" *
+  ```
+  If you have a lot of Cloud Posse projects under a single directory, then you might try
+  ```
+  grep -l "git\.io/build-harness" * */*
+  ```
+  or for full depth below the current directory
+  ```
+  find . \( -name .terraform -prune -type f \)  -o \( -name build-harness -prune -type f \) -o \( -name 'Makefile*' -o -name 'README*' \)
+  ```
+  
+  ### Updating the affected files
+  
+  Once you are happy with the command to generate the list of files to update, update the files by inserting that command into this command template:
+  ```
+  sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(<command to list files>)
+  ```
+  
+  #### Examples
+  
+  The quickest update will be if you only have a single project to update, in which case you can `cd` into the project root directory and
+  ```
+  sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" *)
+  ```
+  
+  If you have multiple projects to update and want to be thorough, then this is probably best:
+  ```
+  sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(find . \( -name .terraform -prune -type f \)  -o \( -name build-harness -prune -type f \) -o \( -name 'Makefile*' -o -name 'README*' \) )
+  ```
+
+  This is the most thorough, but probably overkill for most people:
   ```
   sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" -R .)
   ```
-
 
 # Introduction to the project
 #introduction: |-

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -87,7 +87,7 @@ clean::
 
 # Workaround for https://github.com/actions/checkout/issues/766
 safe-directory:
-	[[ -z "$$GITHUB_WORKSPACE" ]] || git config --global --add safe.directory "$$GITHUB_WORKSPACE"
+	[[ -n "$$GITHUB_WORKSPACE" ]] && git config --global --add safe.directory "$$GITHUB_WORKSPACE" || git config --global --add safe.directory '*'
 
 .PHONY: build-harness/shell builder build-harness/shell/pull builder/pull builder/build builder-slim/build
 


### PR DESCRIPTION
## what
- Better handling of `git` `safe.directory`
- Allow update of Docker image via Workflow Dispatch
- Updated instructions for `git.io` -> `cloudposse.tools`

## why
- Do not depend on `GITHUB_WORKSPACE` being set, since it will not be outside of a GitHub action
- More control over updates and bad builds
- Initial instructions can be overkill
