### PR TITLE
Fix Docker image build on Workflow Dispatch

### DIFF
--- a/.github/.github-CODEOWNERS-update-disabled
+++ b/.github/.github-CODEOWNERS-update-disabled
@@ -1,0 +1,7 @@
+This presence of a .github/.github-CODEOWNERS-update-disabled file
+prevents `make github/update` from modifying the CODEOWNERS file
+while allowing all other `github/update` changes to proceed.
+You can prevent all `github/update` changes, including changes to CODEOWNERS,
+by adding a .github/.github-update-disabled file, in which case
+a .github/.github-CODEOWNERS-update-disabled file is redundant.
+The contents of these files are ignored, only their presence or absence matters.

--- a/.github/.github-update-disabled
+++ b/.github/.github-update-disabled
@@ -1,3 +1,6 @@
 This presence of a .github/.github-update-disabled file
-prevents `make github/update` from making any changes.
-The contents of the file are ignored.
+prevents `make github/update` from making any changes including
+changes to the CODEOWNERS file. You can prevent changes to
+CODEOWNERS while allowing all other normal `github/update` changes
+by creating a .github/.github-CODEOWNERS-update-disabled file instead.
+The contents of these files are ignored, only their presence or absence matters.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
     - name: Prepare tags for Docker image
-      if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule'
+      if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       id: prepare
       run: |
         COMMIT_SHA="${GITHUB_SHA}"
@@ -56,7 +56,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Login to DockerHub
-      if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule'
+      if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -65,12 +65,12 @@ jobs:
       id: docker_full_build
       uses: docker/build-push-action@v2
       with:
-        push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' }}
+        push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         tags: ${{ steps.prepare.outputs.tags }}
     - name: "Build and push slim docker image to DockerHub"
       id: docker_slim_build
       uses: docker/build-push-action@v2
       with:
         file: ./Dockerfile.slim
-        push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' }}
+        push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         tags: ${{ steps.prepare.outputs.slim-tags }}

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@
 This `build-harness` is a collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more.
 It's designed to work with CI/CD systems such as GitHub Actions, Codefresh, Travis CI, CircleCI and Jenkins.
 
-## IMPORTANT BREAKING CHANGE - GIT.IO DEPRECATION
+## Regarding the phase out of `git.io`
 
 Prior to April 25, 2022, practically all Cloud Posse Makefiles pulled in a common Makefile via
 ```
 curl -sSL -o .build-harness "https://git.io/build-harness"
 ```
 
-The `git.io` service is a link shortener/redirector provided by GitHub, but they no longer support it.
+The `git.io` service is a link shortener/redirector provided by GitHub, but [they no longer support it](https://github.blog/changelog/2022-04-25-git-io-deprecation/).
 We have therefore set up `https://cloudposse.tools/build-harness` as an alternative and are migrating
 all our Makefiles to use that URL instead. We encourage you to update any references you have in your
 own code derived from our code, whether by forking one of our repos or simply following one of our examples.
@@ -323,7 +323,7 @@ Available targets:
 <!-- markdownlint-restore -->
 # GIT.IO DEPRECATION
 
-On April 25, 2022, GitHub announced that the [`git.io` redirector service would be shutting down on 2022-04-29](https://github.blog/changelog/2022-04-25-git-io-deprecation/), merely 4 days later. The announcement said that all references to `git.io/build-harness` 
+On April 25, 2022, GitHub announced that the [`git.io` redirector service would be shutting down on 2022-04-29](https://github.blog/changelog/2022-04-25-git-io-deprecation/), merely 4 days later. The announcement said that all references to `git.io` 
 would stop working that day.
 
 This was a major breaking change for Cloud Posse, because *all* of our standard Makefiles include a Makefile from this `build-harness`
@@ -333,8 +333,8 @@ break once that link stopped redirecting to the appropriate content.
 Cloud Posse quickly set up `https://cloudposse.tools/build-harness` as a long-term replacement for `git.io`
 and undertook an emergency update of all of our repositories to make this change.
 
-While we were largely successful in updating our repositories, Cloud Posse was not fully prepared to make the
-mass updates across all of our repositories that this required, so some repositories were not updated. Furthermore,
+While we were largely successful in updating our repositories by 2022-04-29, Cloud Posse was not fully prepared to make the
+mass updates across all of our repositories that this required, so some repositories were not updated in time. Furthermore,
 even if all of Cloud Posse's repositories were updated, that would not affect anyone's fork or clone or 
 locally checked-out version, so we are publishing the instructions below to help you update your own code.
 
@@ -343,13 +343,15 @@ an URL shorting/link redirecting service, and reversed their decision to shut do
 they agreed to archive the links and continue to serve existing links indefinitely, with the caveat that they
 would remove links on a case-by-case basis if they were found to be malicious, misleading, or broken. 
 
-This means that instead of being an urgent requirement that you immediately change your links or your builds will break,
+This means that instead of being an urgent requirement that you immediately change your links, or else your builds would break,
 it is now merely a recommended best practice that you update to the new link that Cloud Posse controls and 
 is committed to maintaining. 
 
-This means that you should replace all references to `git.io/build-harness` with `cloudposse.tools/build-harness`.
-Critical references are in Makefiles, and there are also important references in README files that describe Makefiles. 
-Below we provide guidance on how to make the updates.
+Specifically, in source files you control, you should update all references to `git.io/build-harness`
+to instead refer to `cloudposse.tools/build-harness`. Critical references are in Makefiles, and there are also 
+important references in README files that describe Makefiles. References in derived or downloaded files, such as 
+Terraform modules downloaded by `terraform init`, do not need to be modified.
+Below we provide guidance on how to make the replacements.
 
 ## Automating the update process
 

--- a/README.md
+++ b/README.md
@@ -31,62 +31,19 @@
 This `build-harness` is a collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more.
 It's designed to work with CI/CD systems such as GitHub Actions, Codefresh, Travis CI, CircleCI and Jenkins.
 
-# IMPORTANT BREAKING CHANGE - GIT.IO DEPRECATION
+## IMPORTANT BREAKING CHANGE - GIT.IO DEPRECATION
 
-GitHub announced that the [`git.io` redirector service is shutting down on 2022-04-29](https://github.blog/changelog/2022-04-25-git-io-deprecation/). This means all references to `git.io/build-harness` will stop working.
-
-We have acquired `cloudposse.tools` to mitigate this. Update all references of `git.io/build-harness` with `cloudposse.tools/build-harness`.
-Critical references are in Makefiles, and there are also important references in README files that describe Makefiles.
-
-## Automating the update process
-
-In all cases, these commands are intended to be run from a directory at the top of the directory tree 
-under which all your potentially affected code resides. Usually either the top-level directory of a single `git` repo
-or a `src` (or similar) directory under which you have all your `git` repos (directly or in subdirectories).
-
-### Finding affected files
-
-Use the following command to find all occurrences in all directories recursively:
+Prior to April 25, 2022, practically all Cloud Posse Makefiles pulled in a common Makefile via
 ```
-grep -l "git\.io/build-harness" -R .
-```
-Note that the above command can reach very deeply, such as into Terraform modules you have downloaded. You may want to impose some limits.
-If you run from the top level of a `git` repo, where there is a `Makefile` and a `Dockerfile`, you can reduce that to
-```
-grep -l "git\.io/build-harness" *
-```
-If you have a lot of Cloud Posse projects under a single directory, then you might try
-```
-grep -l "git\.io/build-harness" * */*
-```
-or for full depth below the current directory
-```
-find . \( -name .terraform -prune -type f \)  -o \( -name build-harness -prune -type f \) -o \( -name 'Makefile*' -o -name 'README*' \) -type f
+curl -sSL -o .build-harness "https://git.io/build-harness"
 ```
 
-### Updating the affected files
+The `git.io` service is a link shortener/redirector provided by GitHub, but they no longer support it.
+We have therefore set up `https://cloudposse.tools/build-harness` as an alternative and are migrating
+all our Makefiles to use that URL instead. We encourage you to update any references you have in your
+own code derived from our code, whether by forking one of our repos or simply following one of our examples.
 
-Once you are happy with the command to generate the list of files to update, update the files by inserting that command into this command template:
-```
-sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(<command to list files>)
-```
-
-#### Examples
-
-The quickest update will be if you only have a single project to update, in which case you can `cd` into the project root directory and
-```
-sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" *)
-```
-
-If you have multiple projects to update and want to be thorough, then this is probably best:
-```
-sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(find . \( -name .terraform -prune -type f \)  -o \( -name build-harness -prune -type f \) -o \( -name 'Makefile*' -o -name 'README*' \) -type f )
-```
-
-This is the most thorough, but probably overkill for most people:
-```
-sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" -R .)
-```
+Full details are available in our [`git.io` deprecation documentation](docs/git-io-deprecation.md).
 
 ---
 
@@ -364,6 +321,86 @@ Available targets:
   aws/install                         Install aws cli bundle
 ```
 <!-- markdownlint-restore -->
+# GIT.IO DEPRECATION
+
+On April 25, 2022, GitHub announced that the [`git.io` redirector service would be shutting down on 2022-04-29](https://github.blog/changelog/2022-04-25-git-io-deprecation/), merely 4 days later. The announcement said that all references to `git.io/build-harness` 
+would stop working that day.
+
+This was a major breaking change for Cloud Posse, because *all* of our standard Makefiles include a Makefile from this `build-harness`
+project explicitly, by downloading (via `curl`) `https://git.io/build-harness`, meaning all our Makefiles would
+break once that link stopped redirecting to the appropriate content.
+
+Cloud Posse quickly set up `https://cloudposse.tools/build-harness` as a long-term replacement for `git.io`
+and undertook an emergency update of all of our repositories to make this change.
+
+While we were largely successful in updating our repositories, Cloud Posse was not fully prepared to make the
+mass updates across all of our repositories that this required, so some repositories were not updated. Furthermore,
+even if all of Cloud Posse's repositories were updated, that would not affect anyone's fork or clone or 
+locally checked-out version, so we are publishing the instructions below to help you update your own code.
+
+Fortunately, GitHub recognized the massive upheaval and loss that would be caused by completely shutting down
+an URL shorting/link redirecting service, and reversed their decision to shut down `git.io` completely. Instead,
+they agreed to archive the links and continue to serve existing links indefinitely, with the caveat that they
+would remove links on a case-by-case basis if they were found to be malicious, misleading, or broken. 
+
+This means that instead of being an urgent requirement that you immediately change your links or your builds will break,
+it is now merely a recommended best practice that you update to the new link that Cloud Posse controls and 
+is committed to maintaining. 
+
+This means that you should replace all references to `git.io/build-harness` with `cloudposse.tools/build-harness`.
+Critical references are in Makefiles, and there are also important references in README files that describe Makefiles. 
+Below we provide guidance on how to make the updates.
+
+## Automating the update process
+
+In all cases, these commands are intended to be run from a directory at the top of the directory tree
+under which all your potentially affected code resides. Usually either the top-level directory of a single `git` repo
+or a `src` (or similar) directory under which you have all your `git` repos (directly or in subdirectories).
+
+### Finding affected files
+
+Use the following command to find all occurrences in all directories recursively:
+```
+grep -l "git\.io/build-harness" -R .
+```
+Note that the above command can reach very deeply, such as into Terraform modules you have downloaded. You may want to impose some limits.
+If you run from the top level of a `git` repo, where there is a `Makefile` and a `Dockerfile`, you can reduce that to
+```
+grep -l "git\.io/build-harness" *
+```
+If you have a lot of Cloud Posse projects under a single directory, then you might try
+```
+grep -l "git\.io/build-harness" * */*
+```
+or for full depth below the current directory
+```
+find . \( -name .terraform -prune -type f \)  -o \( -name build-harness -prune -type f \) -o \( -name 'Makefile*' -o -name 'README*' \) -type f
+```
+
+### Updating the affected files
+
+Once you are happy with the command to generate the list of files to update, update the files by inserting that command into this command template:
+```
+sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(<command to list files>)
+```
+
+#### Examples
+
+The quickest update will be if you only have a single project to update, in which case you can `cd` into the project root directory and
+```
+sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" *)
+```
+
+If you have multiple projects to update and want to be thorough, then this is probably best:
+```
+sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(find . \( -name .terraform -prune -type f \)  -o \( -name build-harness -prune -type f \) -o \( -name 'Makefile*' -o -name 'README*' \) -type f )
+```
+
+This is the most thorough, but probably overkill for most people:
+```
+sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" -R .)
+```
+
 
 
 
@@ -462,7 +499,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2016-2022 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2016-2022-2022 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -16,7 +16,7 @@ license: "APACHE2"
 copyrights:
   - name: "Cloud Posse, LLC"
     url: "https://cloudposse.com"
-    year: "2016"
+    year: "2016-2022"
 
 # Canonical GitHub repo
 github_repo: cloudposse/build-harness
@@ -61,62 +61,19 @@ description: |-
   This `build-harness` is a collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more.
   It's designed to work with CI/CD systems such as GitHub Actions, Codefresh, Travis CI, CircleCI and Jenkins.
   
-  # IMPORTANT BREAKING CHANGE - GIT.IO DEPRECATION
+  ## IMPORTANT BREAKING CHANGE - GIT.IO DEPRECATION
 
-  GitHub announced that the [`git.io` redirector service is shutting down on 2022-04-29](https://github.blog/changelog/2022-04-25-git-io-deprecation/). This means all references to `git.io/build-harness` will stop working.
-  
-  We have acquired `cloudposse.tools` to mitigate this. Update all references of `git.io/build-harness` with `cloudposse.tools/build-harness`.
-  Critical references are in Makefiles, and there are also important references in README files that describe Makefiles.
-  
-  ## Automating the update process
-  
-  In all cases, these commands are intended to be run from a directory at the top of the directory tree 
-  under which all your potentially affected code resides. Usually either the top-level directory of a single `git` repo
-  or a `src` (or similar) directory under which you have all your `git` repos (directly or in subdirectories).
-
-  ### Finding affected files
-
-  Use the following command to find all occurrences in all directories recursively:
+  Prior to April 25, 2022, practically all Cloud Posse Makefiles pulled in a common Makefile via
   ```
-  grep -l "git\.io/build-harness" -R .
-  ```
-  Note that the above command can reach very deeply, such as into Terraform modules you have downloaded. You may want to impose some limits.
-  If you run from the top level of a `git` repo, where there is a `Makefile` and a `Dockerfile`, you can reduce that to
-  ```
-  grep -l "git\.io/build-harness" *
-  ```
-  If you have a lot of Cloud Posse projects under a single directory, then you might try
-  ```
-  grep -l "git\.io/build-harness" * */*
-  ```
-  or for full depth below the current directory
-  ```
-  find . \( -name .terraform -prune -type f \)  -o \( -name build-harness -prune -type f \) -o \( -name 'Makefile*' -o -name 'README*' \) -type f
+  curl -sSL -o .build-harness "https://git.io/build-harness"
   ```
   
-  ### Updating the affected files
+  The `git.io` service is a link shortener/redirector provided by GitHub, but they no longer support it.
+  We have therefore set up `https://cloudposse.tools/build-harness` as an alternative and are migrating
+  all our Makefiles to use that URL instead. We encourage you to update any references you have in your
+  own code derived from our code, whether by forking one of our repos or simply following one of our examples.
   
-  Once you are happy with the command to generate the list of files to update, update the files by inserting that command into this command template:
-  ```
-  sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(<command to list files>)
-  ```
-  
-  #### Examples
-  
-  The quickest update will be if you only have a single project to update, in which case you can `cd` into the project root directory and
-  ```
-  sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" *)
-  ```
-  
-  If you have multiple projects to update and want to be thorough, then this is probably best:
-  ```
-  sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(find . \( -name .terraform -prune -type f \)  -o \( -name build-harness -prune -type f \) -o \( -name 'Makefile*' -o -name 'README*' \) -type f )
-  ```
-
-  This is the most thorough, but probably overkill for most people:
-  ```
-  sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" -R .)
-  ```
+  Full details are available in our [`git.io` deprecation documentation](docs/git-io-deprecation.md).
 
 # Introduction to the project
 #introduction: |-
@@ -179,6 +136,7 @@ include:
   - "docs/targets.md"
   - "docs/extensions.md"
   - "docs/auto-init.md"
+  - "docs/git-io-deprecation.md"
 
 # Contributors to this project
 contributors:

--- a/README.yaml
+++ b/README.yaml
@@ -61,14 +61,14 @@ description: |-
   This `build-harness` is a collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more.
   It's designed to work with CI/CD systems such as GitHub Actions, Codefresh, Travis CI, CircleCI and Jenkins.
   
-  ## IMPORTANT BREAKING CHANGE - GIT.IO DEPRECATION
+  ## Regarding the phase out of `git.io`
 
   Prior to April 25, 2022, practically all Cloud Posse Makefiles pulled in a common Makefile via
   ```
   curl -sSL -o .build-harness "https://git.io/build-harness"
   ```
   
-  The `git.io` service is a link shortener/redirector provided by GitHub, but they no longer support it.
+  The `git.io` service is a link shortener/redirector provided by GitHub, but [they no longer support it](https://github.blog/changelog/2022-04-25-git-io-deprecation/).
   We have therefore set up `https://cloudposse.tools/build-harness` as an alternative and are migrating
   all our Makefiles to use that URL instead. We encourage you to update any references you have in your
   own code derived from our code, whether by forking one of our repos or simply following one of our examples.

--- a/docs/git-io-deprecation.md
+++ b/docs/git-io-deprecation.md
@@ -1,0 +1,80 @@
+# GIT.IO DEPRECATION
+
+On April 25, 2022, GitHub announced that the [`git.io` redirector service would be shutting down on 2022-04-29](https://github.blog/changelog/2022-04-25-git-io-deprecation/), merely 4 days later. The announcement said that all references to `git.io/build-harness` 
+would stop working that day.
+
+This was a major breaking change for Cloud Posse, because *all* of our standard Makefiles include a Makefile from this `build-harness`
+project explicitly, by downloading (via `curl`) `https://git.io/build-harness`, meaning all our Makefiles would
+break once that link stopped redirecting to the appropriate content.
+
+Cloud Posse quickly set up `https://cloudposse.tools/build-harness` as a long-term replacement for `git.io`
+and undertook an emergency update of all of our repositories to make this change.
+
+While we were largely successful in updating our repositories, Cloud Posse was not fully prepared to make the
+mass updates across all of our repositories that this required, so some repositories were not updated. Furthermore,
+even if all of Cloud Posse's repositories were updated, that would not affect anyone's fork or clone or 
+locally checked-out version, so we are publishing the instructions below to help you update your own code.
+
+Fortunately, GitHub recognized the massive upheaval and loss that would be caused by completely shutting down
+an URL shorting/link redirecting service, and reversed their decision to shut down `git.io` completely. Instead,
+they agreed to archive the links and continue to serve existing links indefinitely, with the caveat that they
+would remove links on a case-by-case basis if they were found to be malicious, misleading, or broken. 
+
+This means that instead of being an urgent requirement that you immediately change your links or your builds will break,
+it is now merely a recommended best practice that you update to the new link that Cloud Posse controls and 
+is committed to maintaining. 
+
+This means that you should replace all references to `git.io/build-harness` with `cloudposse.tools/build-harness`.
+Critical references are in Makefiles, and there are also important references in README files that describe Makefiles. 
+Below we provide guidance on how to make the updates.
+
+## Automating the update process
+
+In all cases, these commands are intended to be run from a directory at the top of the directory tree
+under which all your potentially affected code resides. Usually either the top-level directory of a single `git` repo
+or a `src` (or similar) directory under which you have all your `git` repos (directly or in subdirectories).
+
+### Finding affected files
+
+Use the following command to find all occurrences in all directories recursively:
+```
+grep -l "git\.io/build-harness" -R .
+```
+Note that the above command can reach very deeply, such as into Terraform modules you have downloaded. You may want to impose some limits.
+If you run from the top level of a `git` repo, where there is a `Makefile` and a `Dockerfile`, you can reduce that to
+```
+grep -l "git\.io/build-harness" *
+```
+If you have a lot of Cloud Posse projects under a single directory, then you might try
+```
+grep -l "git\.io/build-harness" * */*
+```
+or for full depth below the current directory
+```
+find . \( -name .terraform -prune -type f \)  -o \( -name build-harness -prune -type f \) -o \( -name 'Makefile*' -o -name 'README*' \) -type f
+```
+
+### Updating the affected files
+
+Once you are happy with the command to generate the list of files to update, update the files by inserting that command into this command template:
+```
+sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(<command to list files>)
+```
+
+#### Examples
+
+The quickest update will be if you only have a single project to update, in which case you can `cd` into the project root directory and
+```
+sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" *)
+```
+
+If you have multiple projects to update and want to be thorough, then this is probably best:
+```
+sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(find . \( -name .terraform -prune -type f \)  -o \( -name build-harness -prune -type f \) -o \( -name 'Makefile*' -o -name 'README*' \) -type f )
+```
+
+This is the most thorough, but probably overkill for most people:
+```
+sed -i '' 's/git.io\/build-harness/cloudposse.tools\/build-harness/' $(grep -l "git\.io/build-harness" -R .)
+```
+

--- a/docs/git-io-deprecation.md
+++ b/docs/git-io-deprecation.md
@@ -1,6 +1,6 @@
 # GIT.IO DEPRECATION
 
-On April 25, 2022, GitHub announced that the [`git.io` redirector service would be shutting down on 2022-04-29](https://github.blog/changelog/2022-04-25-git-io-deprecation/), merely 4 days later. The announcement said that all references to `git.io/build-harness` 
+On April 25, 2022, GitHub announced that the [`git.io` redirector service would be shutting down on 2022-04-29](https://github.blog/changelog/2022-04-25-git-io-deprecation/), merely 4 days later. The announcement said that all references to `git.io` 
 would stop working that day.
 
 This was a major breaking change for Cloud Posse, because *all* of our standard Makefiles include a Makefile from this `build-harness`
@@ -10,8 +10,8 @@ break once that link stopped redirecting to the appropriate content.
 Cloud Posse quickly set up `https://cloudposse.tools/build-harness` as a long-term replacement for `git.io`
 and undertook an emergency update of all of our repositories to make this change.
 
-While we were largely successful in updating our repositories, Cloud Posse was not fully prepared to make the
-mass updates across all of our repositories that this required, so some repositories were not updated. Furthermore,
+While we were largely successful in updating our repositories by 2022-04-29, Cloud Posse was not fully prepared to make the
+mass updates across all of our repositories that this required, so some repositories were not updated in time. Furthermore,
 even if all of Cloud Posse's repositories were updated, that would not affect anyone's fork or clone or 
 locally checked-out version, so we are publishing the instructions below to help you update your own code.
 
@@ -20,13 +20,15 @@ an URL shorting/link redirecting service, and reversed their decision to shut do
 they agreed to archive the links and continue to serve existing links indefinitely, with the caveat that they
 would remove links on a case-by-case basis if they were found to be malicious, misleading, or broken. 
 
-This means that instead of being an urgent requirement that you immediately change your links or your builds will break,
+This means that instead of being an urgent requirement that you immediately change your links, or else your builds would break,
 it is now merely a recommended best practice that you update to the new link that Cloud Posse controls and 
 is committed to maintaining. 
 
-This means that you should replace all references to `git.io/build-harness` with `cloudposse.tools/build-harness`.
-Critical references are in Makefiles, and there are also important references in README files that describe Makefiles. 
-Below we provide guidance on how to make the updates.
+Specifically, in source files you control, you should update all references to `git.io/build-harness`
+to instead refer to `cloudposse.tools/build-harness`. Critical references are in Makefiles, and there are also 
+important references in README files that describe Makefiles. References in derived or downloaded files, such as 
+Terraform modules downloaded by `terraform init`, do not need to be modified.
+Below we provide guidance on how to make the replacements.
 
 ## Automating the update process
 

--- a/modules/github/Makefile.init
+++ b/modules/github/Makefile.init
@@ -1,5 +1,4 @@
 GITHUB_TEMPLATES = \
-	.github/CODEOWNERS \
 	.github/PULL_REQUEST_TEMPLATE.md \
 	.github/ISSUE_TEMPLATE/config.yml \
 	.github/ISSUE_TEMPLATE/feature_request.md \
@@ -17,10 +16,24 @@ GITHUB_TERRAFORM_TEMPLATES = .github/workflows/chatops.yml \
 	.github/mergify.yml \
 	.github/renovate.json
 
+GTIHUB_CODEOWNERS_FILE = .github/CODEOWNERS
+
 # Create a file (contents unimportant) with this name
-# to prevent pr/auto-format etc. from updating the GitHub templates.
+# to prevent pr/auto-format etc. from updating the GitHub templates, including CODEOWNERS.
 GITHUB_UPDATE_DISABLE_SENTINEL := .github/.github-update-disabled
 
+# Create a file (contents unimportant) with this name to prevent pr/auto-format etc.
+# from updating/replacing the CODEOWNERS file while still allowing other updates.
+GITHUB_CODEOWNERS_UPDATE_DISABLE_SENTINEL := .github/.github-CODEOWNERS-update-disabled
+
+ifeq (,$(wildcard $(GITHUB_CODEOWNERS_UPDATE_DISABLE_SENTINEL)))
+  GITHUB_TEMPLATES += $(GTIHUB_CODEOWNERS_FILE)
+endif
+
+# We cannot rely on modification dates to tell which files are out of date,
+# so we cannot use a traditional make rule. Instead, we use a phony target
+# to ensure the recipe always runs, and copy over all the files and then
+# ask `git` what has changed.
 $(GITHUB_TEMPLATES): $(addprefix $(BUILD_HARNESS_PATH)/templates/, $(GITHUB_TEMPLATES))
 	@mkdir -p $(dir $@)
 	@cp $(BUILD_HARNESS_PATH)/templates/$@ $@
@@ -62,3 +75,4 @@ endif
 
 github/update/start:
 	@printf "\n** GitHub workflows update started **\n\n"
+	@[ -f "$(GITHUB_CODEOWNERS_UPDATE_DISABLE_SENTINEL)" ] && printf "** Auto-update of CODEOWNERS file disabled by presence of %s **\n\n"  "$(GITHUB_CODEOWNERS_UPDATE_DISABLE_SENTINEL)"


### PR DESCRIPTION
## what
* Allow disabling CODEOWNERS automatic update
* Fix Docker image build on Workflow Dispatch
* Update documentation on `git.io` phase out

## why
* Allow repositories to have custom CODEOWNERS files that are not automatically overwritten
* Previous change to allow workflow dispatch of Docker image build only built the image, it did not label and publish it.
* Reduced urgency since GitHub reversed their decision to completely shutdown `git.io` on 2022-04-29