### PR TITLE
Build Docker image when release published, not created

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,9 @@ on:
     types: [opened, synchronize, reopened]
   release:
     types:
-    - created
+    # "released" excludes pre-releases
+    # "published" is either a release or a pre-release
+    - published
   schedule:
     # Example of job definition:
     # .---------------- minute (0 - 59)
@@ -27,7 +29,7 @@ jobs:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
     - name: Prepare tags for Docker image
-      if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      if: (github.event_name == 'release' && github.event.action == 'published') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       id: prepare
       run: |
         COMMIT_SHA="${GITHUB_SHA}"
@@ -37,6 +39,7 @@ jobs:
           VERSION=pr-${{ github.event.pull_request.number }}-merge
           COMMIT_SHA=${{ github.event.pull_request.head.sha }}
         fi
+        printf "Version resolved to %s\n" "${VERSION}"
         TAGS=${{ github.repository }}:sha-${COMMIT_SHA:0:7}
         SLIM_TAGS=${{ github.repository }}:slim-sha-${COMMIT_SHA:0:7}
         if [[ -n $VERSION ]]; then
@@ -52,11 +55,13 @@ jobs:
           SLIM_TAGS="$SLIM_TAGS,${{ github.repository }}:slim-latest,${{ github.repository }}:slim-nightly"
         fi
         echo ::set-output name=tags::${TAGS}
+        printf "TAGS are %s\n" "${TAGS}"
         echo ::set-output name=slim-tags::${SLIM_TAGS}
+        printf "SLIM_TAGS are %s\n" "${SLIM_TAGS}"
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Login to DockerHub
-      if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      if: (github.event_name == 'release' && github.event.action == 'published') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -65,12 +70,12 @@ jobs:
       id: docker_full_build
       uses: docker/build-push-action@v2
       with:
-        push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        push: ${{ (github.event_name == 'release' && github.event.action == 'published') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         tags: ${{ steps.prepare.outputs.tags }}
     - name: "Build and push slim docker image to DockerHub"
       id: docker_slim_build
       uses: docker/build-push-action@v2
       with:
         file: ./Dockerfile.slim
-        push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        push: ${{ (github.event_name == 'release' && github.event.action == 'published') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         tags: ${{ steps.prepare.outputs.slim-tags }}

--- a/modules/github/Makefile.init
+++ b/modules/github/Makefile.init
@@ -75,4 +75,4 @@ endif
 
 github/update/start:
 	@printf "\n** GitHub workflows update started **\n\n"
-	@[ -f "$(GITHUB_CODEOWNERS_UPDATE_DISABLE_SENTINEL)" ] && printf "** Auto-update of CODEOWNERS file disabled by presence of %s **\n\n"  "$(GITHUB_CODEOWNERS_UPDATE_DISABLE_SENTINEL)"
+	@[ -f "$(GITHUB_CODEOWNERS_UPDATE_DISABLE_SENTINEL)" ] && printf "** Auto-update of CODEOWNERS file disabled by presence of %s **\n\n"  "$(GITHUB_CODEOWNERS_UPDATE_DISABLE_SENTINEL)" || true


### PR DESCRIPTION
## what
- Build Docker image when release is published, not created
- Fix `github/update` in the case where CODEOWNERS should be updated

## why
- With `no-release`, the release is still `created` as a Draft when the PR is merged. We want to build the Docker image with the release is `published` instead.
- Bug introduced in #319 broke normal case