### PR TITLE
Autoclose dependency dashboard

### DIFF
--- a/modules/github/Makefile.init
+++ b/modules/github/Makefile.init
@@ -27,7 +27,7 @@ GITHUB_UPDATE_DISABLE_SENTINEL := .github/.github-update-disabled
 GITHUB_CODEOWNERS_UPDATE_DISABLE_SENTINEL := .github/.github-CODEOWNERS-update-disabled
 
 ifeq (,$(wildcard $(GITHUB_CODEOWNERS_UPDATE_DISABLE_SENTINEL)))
-  GITHUB_TEMPLATES += $(GTIHUB_CODEOWNERS_FILE)
+	GITHUB_TEMPLATES += $(GTIHUB_CODEOWNERS_FILE)
 endif
 
 # We cannot rely on modification dates to tell which files are out of date,

--- a/templates/terraform/.github/renovate.json
+++ b/templates/terraform/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-


### PR DESCRIPTION
## what
* Autoclose the dependency dashboard

## why
* The config:base preset enables the dependency dashboard and this will auto close it if there aren't any open dependency related PRs

## references
* https://docs.renovatebot.com/presets-config/#configbase
* https://docs.renovatebot.com/configuration-options/#dependencydashboardautoclose
* Previous incorrect PR https://github.com/cloudposse/terraform-example-module/pull/26


