### PR TITLE
feat: updates Docker module to enable support for podman

### DIFF
--- a/modules/docker/Makefile
+++ b/modules/docker/Makefile
@@ -1,4 +1,4 @@
-DOCKER = $(shell which docker)
+DOCKER ?= $(shell which docker)
 
 DOCKER_RUN ?= docker run -i --rm --network=$(DOCKER_NETWORK)
 DOCKER_EXEC ?= $(DOCKER) exec -it


### PR DESCRIPTION
## what
* Single line to change to enable overriding the `DOCKER` var in `modules/docker`


## why
* Docker + Podman have basically the same CLI usage, so enabling the `DOCKER` var to be overridden enables passing `DOCKER=$(which podman)` when invoking a make target.

## references
* Podman [command reference](https://docs.podman.io/en/latest/Commands.html)
* Docker [command reference](https://docs.docker.com/engine/reference/commandline/cli/)

