### PR TITLE
Remove no-release from patch

### DIFF
--- a/templates/.github/auto-release.yml
+++ b/templates/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:


### PR DESCRIPTION
## what
* Remove no-release from patch

## why
* I believe this is the cause of a `patch` release that follows the merge of an unlabeled PR which followed the merge of a `no-release` labeled PR
* The expectation would be a `minor` release

## references
* https://github.com/cloudposse/terraform-aws-iam-policy/pull/13 `no-release` labeled PR
* https://github.com/cloudposse/terraform-aws-iam-policy/pull/14 unlabeled PR 
* https://github.com/cloudposse/terraform-aws-iam-policy/releases/tag/0.3.1 (should have been 0.4.0)
