### PR TITLE
Mount host directory on /host instead of /opt

### DIFF
--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -173,8 +173,8 @@ build-harness/runner:
 		-e PACKAGES_PREFER_HOST=true \
 		$(addprefix -e ,$(DOCKER_ENVS)) \
 		$(MOUNT_HOME) \
-		-v $(CURDIR):/opt \
-		--workdir /opt \
+		-v $(CURDIR):/host \
+		--workdir /host \
 		--entrypoint $(ENTRYPOINT) \
 		$(RUNNER_DOCKER_IMAGE):$(RUNNER_DOCKER_TAG) $(ARGS)
 


### PR DESCRIPTION
## what

- Mount host file system on `/host` instead of `/opt`

## why

- `/opt` is used by `containerd` and by the container OS (Alpine or Debian) and mounting the local file system on `/opt` may be triggering a Docker bug causing all containers to hang

## references

- https://github.com/docker/for-mac/issues/5081