### PR TITLE
Upgrade go 1.17.9 -> 1.19.0, alpine 3.15 -> 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.9-alpine3.15
+FROM golang:1.19.0-alpine3.16
 LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
 
 LABEL "com.github.actions.name"="Build Harness"
@@ -26,18 +26,20 @@ RUN apk --update --no-cache add \
       py3-cffi && \
     python3 -m pip install --upgrade pip setuptools wheel && \
     pip3 install --no-cache-dir \
+      cryptography==37.0.4 \
       PyYAML==5.4.1 \
-      awscli==1.22.56 \
+      awscli==1.25.43 \
       boto==2.49.0 \
-      boto3==1.21.1 \
+      boto3==1.24.43 \
       iteration-utilities==0.11.0 \
       PyGithub==1.55 && \
     git config --global advice.detachedHead false
 
-## Workaround https://github.com/pypa/pip/issues/5247
-RUN pip3 install --upgrade --force-reinstall pip==9.0.3 && \
-    pip3 install --no-cache-dir --disable-pip-version-check pre-commit && \
-    pip3 install --upgrade pip
+### Workaround https://github.com/pypa/pip/issues/5247
+# Should no longer be needed, but leaving it in case we need to revert
+#RUN pip3 install --upgrade --force-reinstall pip==9.0.3 && \
+#    pip3 install --no-cache-dir --disable-pip-version-check pre-commit && \
+#    pip3 install --upgrade pip
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -fsSL --retry 3 https://apk.cloudposse.com/install.sh | bash
@@ -86,3 +88,4 @@ RUN make -s template/deps readme/deps
 RUN make -s go/deps-build go/deps-dev
 
 ENTRYPOINT ["/usr/bin/make"]
+#ENTRYPOINT ["/bin/sh"]

--- a/modules/go/Makefile.build
+++ b/modules/go/Makefile.build
@@ -27,13 +27,15 @@ go/deps: $(GLIDE)
 go/deps-build:
 	$(call assert-set,GOPATH)
 	mkdir -p  $(GOPATH)/bin
-	which $(GLIDE) || (curl https://glide.sh/get | sh)
+	# 2022-098-02 https://glide.sh/get no longer works (parked domain, bad SSL cert)
+	# which $(GLIDE) || (curl https://glide.sh/get | sh)
+	which $(GLIDE) || apk add --no-cache glide
 
 ## Install development dependencies
 go/deps-dev: $(GO)
 	$(call assert-set,GO)
-	$(GO) get -u -v golang.org/x/lint/golint
-	$(GO) get -u -v github.com/mitchellh/gox
+	$(GO) install golang.org/x/lint/golint@latest
+	$(GO) install github.com/mitchellh/gox@latest
 
 ## Clean compiled binary
 go/clean:


### PR DESCRIPTION
## what
- Upgrade `go` 1.17.9 -> 1.19.0
- Upgrade `alpine` 3.15 -> 3.16
- Upgrade `awscli` and `boto3` to current versions
- Fix obsolete use of `go get` in `modules/go/Makefile.build`
- Fix broken installation of `glide` in `modules/go/Makefile.build`

## why
- Provide up-to-date framework for testing using Terratest

