### PR TITLE
Update pre-commit tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apk --update --no-cache add \
       boto3==1.24.43 \
       iteration-utilities==0.11.0 \
       PyGithub==1.55 && \
+      pre-commit && \
     git config --global advice.detachedHead false
 
 ### Workaround https://github.com/pypa/pip/issues/5247

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,14 @@ RUN apk --update --no-cache add \
       boto3==1.24.43 \
       iteration-utilities==0.11.0 \
       PyGithub==1.55 && \
-      pre-commit && \
     git config --global advice.detachedHead false
+
+# Install pre-commit support
+RUN pip install pre-commit
+# Install ADR tools
+RUN cd /usr/local/bin && curl -fsSL https://github.com/npryce/adr-tools/archive/refs/tags/3.0.0.tar.gz | \
+    tar xzf - adr-tools-3.0.0/src --strip 2
+
 
 ### Workaround https://github.com/pypa/pip/issues/5247
 # Should no longer be needed, but leaving it in case we need to revert
@@ -55,6 +61,7 @@ RUN apk --update --no-cache add \
       helm@cloudposse \
       helmfile@cloudposse \
       codefresh@cloudposse \
+      npm nodejs \
       terraform-0.11@cloudposse terraform-0.12@cloudposse \
       terraform-0.13@cloudposse terraform-0.14@cloudposse \
       terraform-0.15@cloudposse terraform-1@cloudposse \

--- a/templates/.github/workflows/validate-codeowners.yml
+++ b/templates/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"


### PR DESCRIPTION
## what
- Install tools to support Cloud Posse's standard pre-commit hooks

## why
- Restore the functionality of `make pr/pre-commit` for common use cases