### PR TITLE
Replace `set-output` in Templates

### DIFF
--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -54,10 +54,10 @@ jobs:
           [[ $SENDER ==  "cloudpossebot" ]] || git push
           # Set status to fail, because the push should trigger another status check,
           # and we use success to indicate the checks are finished.
-          printf "::set-output name=%s::%s\n" "changed" "true"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
           exit 1
         else
-          printf "::set-output name=%s::%s\n" "changed" "false"
+          echo "changed=false" >> "$GITHUB_OUTPUT"
           echo "No changes detected"
         fi
 

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -1,5 +1,7 @@
 name: Auto Readme
 on:
+  # temporary to test action change
+  pull_request:
   pull_request_target:
     types: [opened, synchronize]
 

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -1,7 +1,5 @@
 name: Auto Readme
 on:
-  # temporary to test action change
-  pull_request:
   pull_request_target:
     types: [opened, synchronize]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,9 +54,9 @@ jobs:
           TAGS="$TAGS,${{ github.repository }}:latest,${{ github.repository }}:nightly"
           SLIM_TAGS="$SLIM_TAGS,${{ github.repository }}:slim-latest,${{ github.repository }}:slim-nightly"
         fi
-        echo ::set-output name=tags::${TAGS}
+        echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
         printf "TAGS are %s\n" "${TAGS}"
-        echo ::set-output name=slim-tags::${SLIM_TAGS}
+        echo "slim-tags=${SLIM_TAGS}" >> "$GITHUB_OUTPUT"
         printf "SLIM_TAGS are %s\n" "${SLIM_TAGS}"
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/templates/terraform/.github/workflows/auto-context.yml
+++ b/templates/terraform/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "create_pull_request = true" >> $GITHUB_OUTPUT
+            echo "create_pull_request=true" >> "$GITHUB_OUTPUT"
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."

--- a/templates/terraform/.github/workflows/auto-context.yml
+++ b/templates/terraform/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "::set-output name=create_pull_request::true"
+            echo "create_pull_request=true\n" >> $GITHUB_OUTPUT
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."

--- a/templates/terraform/.github/workflows/auto-context.yml
+++ b/templates/terraform/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "create_pull_request=true" >> $GITHUB_OUTPUT
+            echo "create_pull_request = true" >> $GITHUB_OUTPUT
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."

--- a/templates/terraform/.github/workflows/auto-context.yml
+++ b/templates/terraform/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "create_pull_request=true\n" >> $GITHUB_OUTPUT
+            echo "create_pull_request=true" >> $GITHUB_OUTPUT
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."

--- a/templates/terraform/.github/workflows/auto-format.yml
+++ b/templates/terraform/.github/workflows/auto-format.yml
@@ -54,10 +54,10 @@ jobs:
           [[ $SENDER ==  "cloudpossebot" ]] || git push
           # Set status to fail, because the push should trigger another status check,
           # and we use success to indicate the checks are finished.
-          echo "changed=true" >> $GITHUB_OUTPUT
+          echo "changed = true" >> $GITHUB_OUTPUT
           exit 1
         else
-          echo "changed=false" >> $GITHUB_OUTPUT
+          echo "changed = false" >> $GITHUB_OUTPUT
           echo "No changes detected"
         fi
 

--- a/templates/terraform/.github/workflows/auto-format.yml
+++ b/templates/terraform/.github/workflows/auto-format.yml
@@ -54,10 +54,10 @@ jobs:
           [[ $SENDER ==  "cloudpossebot" ]] || git push
           # Set status to fail, because the push should trigger another status check,
           # and we use success to indicate the checks are finished.
-          printf "::set-output name=%s::%s\n" "changed" "true"
+          echo "changed=true\n" >> $GITHUB_OUTPUT
           exit 1
         else
-          printf "::set-output name=%s::%s\n" "changed" "false"
+          echo "changed=false\n" >> $GITHUB_OUTPUT
           echo "No changes detected"
         fi
 

--- a/templates/terraform/.github/workflows/auto-format.yml
+++ b/templates/terraform/.github/workflows/auto-format.yml
@@ -54,10 +54,10 @@ jobs:
           [[ $SENDER ==  "cloudpossebot" ]] || git push
           # Set status to fail, because the push should trigger another status check,
           # and we use success to indicate the checks are finished.
-          echo "changed = true" >> $GITHUB_OUTPUT
+          echo "changed=true" >> "$GITHUB_OUTPUT"
           exit 1
         else
-          echo "changed = false" >> $GITHUB_OUTPUT
+          echo "changed=false" >> "$GITHUB_OUTPUT"
           echo "No changes detected"
         fi
 

--- a/templates/terraform/.github/workflows/auto-format.yml
+++ b/templates/terraform/.github/workflows/auto-format.yml
@@ -54,10 +54,10 @@ jobs:
           [[ $SENDER ==  "cloudpossebot" ]] || git push
           # Set status to fail, because the push should trigger another status check,
           # and we use success to indicate the checks are finished.
-          echo "changed=true\n" >> $GITHUB_OUTPUT
+          echo "changed=true" >> $GITHUB_OUTPUT
           exit 1
         else
-          echo "changed=false\n" >> $GITHUB_OUTPUT
+          echo "changed=false" >> $GITHUB_OUTPUT
           echo "No changes detected"
         fi
 

--- a/templates/terraform/.github/workflows/auto-readme.yml
+++ b/templates/terraform/.github/workflows/auto-readme.yml
@@ -29,7 +29,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       run: |
         default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-        echo "defaultBranch=${default_branch}\n" >> $GITHUB_OUTPUT
+        echo "defaultBranch=${default_branch}" >> $GITHUB_OUTPUT
         printf "defaultBranchRef.name=%s\n" "${default_branch}"
 
     - name: Update readme

--- a/templates/terraform/.github/workflows/auto-readme.yml
+++ b/templates/terraform/.github/workflows/auto-readme.yml
@@ -29,7 +29,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       run: |
         default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-        echo "defaultBranch = ${default_branch}" >> "$GITHUB_OUTPUT"
+        echo "defaultBranch=${default_branch}" >> "$GITHUB_OUTPUT"
         printf "defaultBranchRef.name=%s\n" "${default_branch}"
 
     - name: Update readme

--- a/templates/terraform/.github/workflows/auto-readme.yml
+++ b/templates/terraform/.github/workflows/auto-readme.yml
@@ -29,7 +29,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       run: |
         default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-        echo "defaultBranch=${default_branch}" >> $GITHUB_OUTPUT
+        echo "defaultBranch = ${default_branch}" >> $GITHUB_OUTPUT
         printf "defaultBranchRef.name=%s\n" "${default_branch}"
 
     - name: Update readme

--- a/templates/terraform/.github/workflows/auto-readme.yml
+++ b/templates/terraform/.github/workflows/auto-readme.yml
@@ -29,7 +29,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       run: |
         default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-        echo "defaultBranch = ${default_branch}" >> $GITHUB_OUTPUT
+        echo "defaultBranch = ${default_branch}" >> "$GITHUB_OUTPUT"
         printf "defaultBranchRef.name=%s\n" "${default_branch}"
 
     - name: Update readme

--- a/templates/terraform/.github/workflows/auto-readme.yml
+++ b/templates/terraform/.github/workflows/auto-readme.yml
@@ -29,7 +29,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       run: |
         default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-        printf "::set-output name=defaultBranch::%s\n" "${default_branch}"
+        echo "defaultBranch=${default_branch}\n" >> $GITHUB_OUTPUT
         printf "defaultBranchRef.name=%s\n" "${default_branch}"
 
     - name: Update readme


### PR DESCRIPTION
## what
- Replaced set-output in terraform workflow templates

## why
- The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.

## references
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

