### PR TITLE
Gomplate to use predefined config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,5 +16,5 @@
 # Cloud Posse must review any changes to GitHub templates actions
 templates/.github/*             @cloudposse/engineering
 templates/terraform/.github/*   @cloudposse/engineering
-**/.gomplate.* @cloudposse/admins
-**/configs/gomplate.yaml @cloudposse/admins
+**/.gomplate.*                  @cloudposse/admins
+**/configs/gomplate.yaml        @cloudposse/admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,3 +16,4 @@
 # Cloud Posse must review any changes to GitHub templates actions
 templates/.github/*             @cloudposse/engineering
 templates/terraform/.github/*   @cloudposse/engineering
+**/.gomplate.*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,5 @@
 # Cloud Posse must review any changes to GitHub templates actions
 templates/.github/*             @cloudposse/engineering
 templates/terraform/.github/*   @cloudposse/engineering
-**/.gomplate.*
+**/.gomplate.* @cloudposse/admins
+**/configs/gomplate.yaml @cloudposse/admins

--- a/bin/codefresh-sync.sh
+++ b/bin/codefresh-sync.sh
@@ -59,7 +59,7 @@ ${CODEFRESH_CLI} get pipelines ${PIPELINE_FULLNAME} > /dev/null 2>&1
 PIPELINE_IS_NEW=$?
 
 ## Generate pipeline from template
-gomplate -f templates/${ACCOUNT}/${PIPELINE}.yaml -d repository=env:REPOSITORY -d pipeline=env:PIPELINE -o ${PIPELINE_NEW}
+gomplate -f templates/${ACCOUNT}/${PIPELINE}.yaml -d repository=env:REPOSITORY -d pipeline=env:PIPELINE -o ${PIPELINE_NEW} --config configs/gomplate.yaml
 
 if [[ "${PIPELINE_IS_NEW}" == "1" ]]; then
   ## Current pipeline is empty

--- a/modules/docs/Makefile
+++ b/modules/docs/Makefile
@@ -25,7 +25,7 @@ docs/terraform.md: docs/deps packages/install/terraform-docs
 ## Update `docs/github-action.md` from `action.yaml`
 docs/github-action.md: docs/deps packages/install/gomplate
 	@echo "<!-- markdownlint-disable -->" > $@
-	@gomplate -d action=./action.yml -f $(BUILD_HARNESS_PATH)/templates/docs-github-action.gotmpl >> $@
+	@gomplate -d action=./action.yml -f $(BUILD_HARNESS_PATH)/templates/docs-github-action.gotmpl --config $(BUILD_HARNESS_PATH)/configs/gomplate.yaml >> $@
 	@echo "<!-- markdownlint-restore -->" >> $@
 
 .PHONY : docs/github-actions-reusable-workflows.md
@@ -33,5 +33,5 @@ docs/github-action.md: docs/deps packages/install/gomplate
 docs/github-actions-reusable-workflows.md: docs/deps packages/install/gomplate packages/install/yq
 	@echo "<!-- markdownlint-disable -->" > $@
 	@yq eval-all --exit-status --no-colors [.] ./.github/workflows/* | \
-		gomplate -d workflows=stdin:?type=application/yaml -f $(BUILD_HARNESS_PATH)/templates/docs-github-actions-reusable-workflows.gotmpl >> $@
+		gomplate -d workflows=stdin:?type=application/yaml -f $(BUILD_HARNESS_PATH)/templates/docs-github-actions-reusable-workflows.gotmpl --config $(BUILD_HARNESS_PATH)/configs/gomplate.yaml >> $@
 	@echo "<!-- markdownlint-restore -->" >> $@

--- a/modules/readme/Makefile
+++ b/modules/readme/Makefile
@@ -29,8 +29,7 @@ readme/lint:
 
 ## Create README.md by building it from README.yaml
 readme/build: readme/deps $(README_DEPS)
-	@gomplate --file $(README_TEMPLATE_FILE) \
-		--out $(README_FILE) 
+	@gomplate --file $(README_TEMPLATE_FILE) --out $(README_FILE) --config $(BUILD_HARNESS_PATH)/configs/gomplate.yaml
 	@echo "Generated $(README_FILE) from $(README_TEMPLATE_FILE) using data from $(README_TEMPLATE_YAML)"
 
 readme/generate-related-references:


### PR DESCRIPTION
## what

- Define gomplate config and pass it throught CLI flag to every gomplate invocation
- Passing as the very last option to avoid injecting override in the env vars dereferenced later in same command
- unset GOMPLATE_CONFIG is not required as CLI option always takes precedence over env var, I tested.