### PR TITLE
Support release branches and default branch named "main"

### DIFF
--- a/templates/terraform/.github/mergify.yml
+++ b/templates/terraform/.github/mergify.yml
@@ -4,13 +4,17 @@ pull_request_rules:
 - name: "approve automated PRs that have passed checks"
   conditions:
   - "author~=^(cloudpossebot|renovate\\[bot\\])$"
-  - "base=master"
   - "-closed"
   - "head~=^(auto-update|renovate)/.*"
   - "check-success=test/bats"
   - "check-success=test/readme"
   - "check-success=test/terratest"
   - "check-success=validate-codeowners"
+  - or:
+    - "base=master"
+    - "base=main"
+    - "base~=^release/v\\d{1,2}$"
+
   actions:
     review:
       type: "APPROVE"
@@ -20,7 +24,6 @@ pull_request_rules:
 - name: "merge automated PRs when approved and tests pass"
   conditions:
   - "author~=^(cloudpossebot|renovate\\[bot\\])$"
-  - "base=master"
   - "-closed"
   - "head~=^(auto-update|renovate)/.*"
   - "check-success=test/bats"
@@ -30,6 +33,11 @@ pull_request_rules:
   - "#approved-reviews-by>=1"
   - "#changes-requested-reviews-by=0"
   - "#commented-reviews-by=0"
+  - or:
+    - "base=master"
+    - "base=main"
+    - "base~=^release/v\\d{1,2}$"
+
   actions:
     merge:
       method: "squash"
@@ -50,7 +58,10 @@ pull_request_rules:
 
 - name: "remove outdated reviews"
   conditions:
-  - "base=master"
+  - or:
+    - "base=master"
+    - "base=main"
+    - "base~=^release/v\\d{1,2}$"
   actions:
     dismiss_reviews:
       changes_requested: true

--- a/templates/terraform/.github/renovate.json
+++ b/templates/terraform/.github/renovate.json
@@ -3,6 +3,7 @@
     "config:base",
     ":preserveSemverRanges"
   ],
+  "baseBranches": ["main", "master", "/^release\\/v\\d{1,2}$/"],
   "labels": ["auto-update"],
   "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],

--- a/templates/terraform/.github/workflows/auto-context.yml
+++ b/templates/terraform/.github/workflows/auto-context.yml
@@ -11,6 +11,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Find default branch name
+      id: defaultBranch
+      shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+        echo "defaultBranch=${default_branch}" >> "$GITHUB_OUTPUT"
+        printf "defaultBranchRef.name=%s\n" "${default_branch}"
+
     - name: Update context.tf
       shell: bash
       id: update
@@ -50,7 +60,7 @@ jobs:
           To support all the features of the `context` interface.
 
         branch: auto-update/context.tf
-        base: master
+        base: ${{ steps.defaultBranch.outputs.defaultBranch }}
         delete-branch: true
         labels: |
           auto-update


### PR DESCRIPTION
## what

- Support release branches (e.g. `release/v1`) and default branch named "main" for Terraform modules' Mergify and Renovate configurations.

## why

- Migrate default branch names from `master` to `main` per GitHub recommendation
- Enable automated support of release branches. 

## references

- https://github.com/github/renaming#renaming-the-default-branch-from-master
- https://docs.renovatebot.com/configuration-options/#basebranches
- https://docs.mergify.com/conditions/#combining-conditions-with-operators
