### PR TITLE
Add precommit/terraform make target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.0-alpine3.16
+FROM golang:1.20.4-alpine3.17
 LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
 
 LABEL "com.github.actions.name"="Build Harness"
@@ -80,7 +80,7 @@ RUN update-alternatives --set terraform /usr/share/terraform/$DEFAULT_TERRAFORM_
 
 # Install tflint
 RUN curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
-COPY <<EOF .tflint.hcl
+COPY <<EOF /root/.tflint.hcl
 plugin "aws" {
     enabled = true
     version = "0.23.0"

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.17
 LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
 
 LABEL "com.github.actions.name"="Build Harness"
@@ -11,6 +11,7 @@ RUN apk --no-cache add \
       ca-certificates \
       coreutils \
       curl \
+      unzip \
       git \
       gettext \
       grep \
@@ -40,6 +41,17 @@ ARG DEFAULT_TERRAFORM_VERSION=1
 RUN update-alternatives --set terraform /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform && \
   mkdir -p /build-harness/vendor && \
   ln -s /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform /build-harness/vendor/terraform
+
+# Install tflint
+RUN curl -sSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+COPY <<EOF /root/.tflint.hcl
+plugin "aws" {
+    enabled = true
+    version = "0.23.0"
+    source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+EOF
+RUN tflint --init
 
 # Patch for old Makefiles that expect a directory like x.x from the 0.x days.
 # Fortunately, they only look for the current version, so we only need links

--- a/README.md
+++ b/README.md
@@ -565,8 +565,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Sarkis][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis][sarkis_homepage] | [![Alexander Babai][alebabai_avatar]][alebabai_homepage]<br/>[Alexander Babai][alebabai_homepage] | [![Jon Boulle][jonboulle_avatar]][jonboulle_homepage]<br/>[Jon Boulle][jonboulle_homepage] | [![Marcin Brański][3h4x_avatar]][3h4x_homepage]<br/>[Marcin Brański][3h4x_homepage] |
-|---|---|---|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Nuru][Nuru_avatar]][Nuru_homepage]<br/>[Nuru][Nuru_homepage] | [![Sarkis][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis][sarkis_homepage] | [![Alexander Babai][alebabai_avatar]][alebabai_homepage]<br/>[Alexander Babai][alebabai_homepage] | [![Jon Boulle][jonboulle_avatar]][jonboulle_homepage]<br/>[Jon Boulle][jonboulle_homepage] | [![Marcin Brański][3h4x_avatar]][3h4x_homepage]<br/>[Marcin Brański][3h4x_homepage] |
+|---|---|---|---|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
@@ -575,6 +575,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
   [aknysh_homepage]: https://github.com/aknysh
   [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
+  [Nuru_homepage]: https://github.com/Nuru
+  [Nuru_avatar]: https://img.cloudposse.com/150x150/https://github.com/Nuru.png
   [sarkis_homepage]: https://github.com/sarkis
   [sarkis_avatar]: https://img.cloudposse.com/150x150/https://github.com/sarkis.png
   [alebabai_homepage]: https://github.com/alebabai

--- a/README.yaml
+++ b/README.yaml
@@ -146,6 +146,8 @@ contributors:
     github: "goruha"
   - name: "Andriy Knysh"
     github: "aknysh"
+  - name: "Nuru"
+    github: "Nuru"
   - name: "Sarkis"
     github: "sarkis"
   - name: "Alexander Babai"

--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -3,6 +3,10 @@ TERRAFORM ?= $(BUILD_HARNESS_PATH)/vendor/terraform
 TERRAFORM_VERSION ?= 1.0.11
 TERRAFORM_URL ?= https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/terraform_$(TERRAFORM_VERSION)_$(OS)_$(BUILD_HARNESS_ARCH).zip
 
+.PHONY: terraform/install terraform/get-plugins terraform/get-modules terraform/validate terraform/tflint terraform/lint
+.PHONY: terraform/fmt terraform/upgrade-modules terraform/rewrite-module-source terraform/rewrite-readme-source terraform/loosen-constraints
+.PHONY: terraform/bump-tf-12-min-version terraform/rewrite-required-providers terraform/v14-rewrite terraform/precommit
+
 ## Install terraform
 terraform/install:
 	@[ -x $(TERRAFORM) ] || ( \
@@ -122,3 +126,4 @@ terraform/v14-rewrite: terraform/loosen-constraints terraform/bump-tf-12-min-ver
 
 ## Terraform pull-request routine check/update
 terraform/precommit: terraform/fmt terraform/tflint readme/build
+	@# Need a recipe to avoid default recipe

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -122,12 +122,13 @@ build-harness/shell builder pr/pre-commit pr/readme pr/github-update: RUNNER_DOC
 build-harness/shell builder: build-harness/runner
 	@exit 0
 
-.PHONY: build-harness/shell-slim builder-slim pr/auto-format pr/auto-format/host pr/readme pr/readme/host pr/pre-commit pr/github-update pr/github-update/host tf14-upgrade
+.PHONY: build-harness/shell-slim builder-slim pr/readme pr/readme/host pr/pre-commit pr/github-update pr/github-update/host tf14-upgrade
+.PHONY: precommit/terraform pr/auto-format precommit/terraform/host pr/auto-format/host
 
-build-harness/shell-slim builder-slim pr/auto-format pr/readme tf14-upgrade: RUNNER_DOCKER_IMAGE ?= $(BUILD_HARNESS_DOCKER_IMAGE)
+build-harness/shell-slim builder-slim precommit/terraform pr/auto-format pr/readme tf14-upgrade: RUNNER_DOCKER_IMAGE ?= $(BUILD_HARNESS_DOCKER_IMAGE)
 
-build-harness/shell-slim builder-slim tf14-upgrade pr/auto-format pr/readme: RUNNER_DOCKER_SHA_TAG ?= $(shell $(BUILD_HARNESS_DOCKER_SHA_TAG_CMD))
-build-harness/shell-slim builder-slim tf14-upgrade pr/auto-format pr/readme: RUNNER_DOCKER_TAG ?= \
+build-harness/shell-slim builder-slim tf14-upgrade precommit/terraform pr/auto-format pr/readme: RUNNER_DOCKER_SHA_TAG ?= $(shell $(BUILD_HARNESS_DOCKER_SHA_TAG_CMD))
+build-harness/shell-slim builder-slim tf14-upgrade precommit/terraform pr/auto-format pr/readme: RUNNER_DOCKER_TAG ?= \
 	$(shell docker inspect --type=image $(RUNNER_DOCKER_IMAGE):$(RUNNER_DOCKER_SHA_TAG) >/dev/null 2>&1 && \
 	echo "$(RUNNER_DOCKER_SHA_TAG) " || echo "slim-$(RUNNER_DOCKER_SHA_TAG)")
 
@@ -136,13 +137,19 @@ build-harness/shell-slim builder-slim: ARGS := $(if $(TARGETS),$(TARGETS),-l || 
 build-harness/shell-slim builder-slim: ENTRYPOINT := $(if $(TARGETS),/usr/bin/make,/bin/bash)
 build-harness/shell-slim builder-slim: build-harness/runner
 
-pr/auto-format pr/readme pr/pre-commit pr/github-update tf14-upgrade : ENTRYPOINT := /usr/bin/make
+precommit/terraform pr/auto-format pr/readme pr/pre-commit pr/github-update tf14-upgrade : ENTRYPOINT := /usr/bin/make
 
-pr/auto-format pr/auto-format/host: ARGS := github/update terraform/fmt readme
+# Prior to 2023-05-17 (build-harness v1.18.0), before committing changes to a terraform module, you could run
+#   make pr/auto-format
+# which used this setting:
+#   pr/auto-format pr/auto-format/host: ARGS := github/update terraform/fmt readme
+# Now the preferred target is `precommit/terraform` but the old targets are left for backwards compatibility.
+
+precommit/terraform pr/auto-format precommit/terraform/host pr/auto-format/host: ARGS := terraform/precommit
 pr/readme pr/readme/host: ARGS := readme/deps readme
 pr/github-update pr/github-update/host: ARGS := github/update
-pr/auto-format pr/readme pr/github-update: build-harness/runner
-pr/auto-format/host pr/readme/host pr/github-update/host: safe-directory
+precommit/terraform pr/auto-format pr/readme pr/github-update: build-harness/runner
+precommit/terraform/host pr/auto-format/host pr/readme/host pr/github-update/host: safe-directory
 	$(MAKE) $(ARGS)
 
 pr/pre-commit: ARGS := pre-commit/run


### PR DESCRIPTION
## what

- Add `precommit/terraform` `make` target
- Update old `pr/auto-format` `make` target to `make` new `terraform/precommit` target
- Fix `terraform/precommit` target to only run once (not twice)
- Add `tflint` to `build-harness-slim`
- Move `.tflint.hcl` from `/` to `/root` (a.k.a. `$HOME`)
- Update `go` to 1.20.4
- Update Alpine to 3.17

## why

- PR #342 claimed to add `precommit/terraform` target but did not
- Enable people and workflows to run formatting, `tflint`, and other processes locally before opening a PR
- Allow both full and slim Docker images to run `precommit/terraform`
- Move `.tflint.hcl` to where `tflint` expect it to be, in order to support `tflint --enable-plugin=aws`
- Keep frameworks up-to-date
