### PR TITLE
Remove deprecated note from readme template

### DIFF
--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -153,9 +153,6 @@ We highly recommend that in your code you pin the version to the exact version y
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
 
-Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
-the registry shows many of our inputs as required when in fact they are optional.
-The table below correctly indicates which inputs are required.
 {{end}}
 
 {{ (ds "config").usage -}}

--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -152,7 +152,6 @@ difficulty of keeping the versions in the documentation in sync with the latest 
 We highly recommend that in your code you pin the version to the exact version you are
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
-
 {{end}}
 
 {{ (ds "config").usage -}}


### PR DESCRIPTION
## what

Remove deprecated note from readme template

## why

It's been fixed

## references
https://github.com/hashicorp/terraform/issues/21417#issuecomment-1262982023
