### PR TITLE
Revise renovate config 

### DIFF
--- a/templates/terraform/.github/renovate.json
+++ b/templates/terraform/.github/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "config:base",
-    ":preserveSemverRanges"
+    ":preserveSemverRanges",
+    ":rebaseStalePrs"
   ],
   "baseBranches": ["main", "master", "/^release\\/v\\d{1,2}$/"],
   "labels": ["auto-update"],

--- a/templates/terraform/.github/renovate.json
+++ b/templates/terraform/.github/renovate.json
@@ -4,11 +4,11 @@
     ":preserveSemverRanges",
     ":rebaseStalePrs"
   ],
-  "baseBranches": ["main", "master", "/^release\\/v\\d{1,2}$/"],
+  "baseBranches": ["main"],
   "labels": ["auto-update"],
   "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
-    "ignorePaths": ["**/context.tf", "examples/**"]
+    "ignorePaths": ["**/context.tf"]
   }
 }


### PR DESCRIPTION
## what

- Auto rebase stale PRs
- Auto update dependencies in tests (./examples)
- Do not track branches other than `main`. All terraform repos are now migrated to `main`, we also don't want to auto-update release branches since they are supposed to sunset.
 
# why

Reduce chore 

## references

https://www.augmentedmind.de/2021/07/25/renovate-bot-cheat-sheet/
