### PR TITLE
Update pre-commit to run pre-push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout source code at current commit"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Prepare tags for Docker image
       if: (github.event_name == 'release' && github.event.action == 'published') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       id: prepare
@@ -59,22 +59,22 @@ jobs:
         echo "slim-tags=${SLIM_TAGS}" >> "$GITHUB_OUTPUT"
         printf "SLIM_TAGS are %s\n" "${SLIM_TAGS}"
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub
       if: (github.event_name == 'release' && github.event.action == 'published') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     - name: "Build and push full docker image to DockerHub"
       id: docker_full_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         push: ${{ (github.event_name == 'release' && github.event.action == 'published') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         tags: ${{ steps.prepare.outputs.tags }}
     - name: "Build and push slim docker image to DockerHub"
       id: docker_slim_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         file: ./Dockerfile.slim
         push: ${{ (github.event_name == 'release' && github.event.action == 'published') || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,13 @@ RUN apk --update --no-cache add \
       py3-cffi && \
     python3 -m pip install --upgrade pip setuptools wheel && \
     pip3 install --no-cache-dir \
-      cryptography==37.0.4 \
-      PyYAML==5.4.1 \
-      awscli==1.25.43 \
+      cryptography==41.0.2 \
+      PyYAML==6.0.1 \
+      awscli==1.29.9 \
       boto==2.49.0 \
-      boto3==1.24.43 \
+      boto3==1.28.9 \
       iteration-utilities==0.11.0 \
-      PyGithub==1.55 && \
+      PyGithub==1.59 && \
     git config --global advice.detachedHead false
 
 # Install pre-commit support

--- a/modules/pre-commit/Makefile
+++ b/modules/pre-commit/Makefile
@@ -1,5 +1,8 @@
 
-.PHONY: pre-commit/run
+.PHONY: pre-commit/run pre-commit/all
+
+pre-commit/all:
+	pre-commit run --all-files
 
 pre-commit/run:
-	pre-commit run --all-files
+	pre-commit run --hook-stage pre-push


### PR DESCRIPTION
## what

- Update make targets `pr/pre-commit` and `pre-commit/run` to only run the `pre-push` stage of `pre-commit`
- Update Python package versions
- Update Docker GitHub actions

## why

- Target is intended to be used pre-push, and previous target ran against all files, which both took excessively long and sometimes made unwanted changes to large numbers of untouched files.
- PyYaml 5.4.1 no longer installs because of Cython v3, + bug and security fixes
- Migrate away from deprecated features

## references

- https://github.com/yaml/pyyaml/issues/724