### PR TITLE
Handle spaces in path to Docker command

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,4 @@
+---
 name: lint
 
 on:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: cloudposse/build-harness@1.8.0
+      - uses: docker://cloudposse/build-harness:latest
         with:
           entrypoint: /usr/bin/make
           args: readme/lint
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Lint Code Base
-        uses: github/super-linter/slim@v4
+        uses: github/super-linter/slim@v5
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_NATURAL_LANGUAGE: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4-alpine3.17
+FROM golang:1.20.7-alpine3.18
 LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
 
 LABEL "com.github.actions.name"="Build Harness"
@@ -27,13 +27,13 @@ RUN apk --update --no-cache add \
       py3-cffi && \
     python3 -m pip install --upgrade pip setuptools wheel && \
     pip3 install --no-cache-dir \
-      cryptography==41.0.2 \
+      cryptography==41.0.3 \
       PyYAML==6.0.1 \
-      awscli==1.29.9 \
+      awscli==1.29.25 \
       boto==2.49.0 \
-      boto3==1.28.9 \
+      boto3==1.28.25 \
       iteration-utilities==0.11.0 \
-      PyGithub==1.59 && \
+      PyGithub==1.59.1 && \
     git config --global advice.detachedHead false
 
 # Install pre-commit support
@@ -83,7 +83,7 @@ RUN curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/in
 COPY <<EOF /root/.tflint.hcl
 plugin "aws" {
     enabled = true
-    version = "0.23.0"
+    version = "0.26.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 EOF

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.18
 LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
 
 LABEL "com.github.actions.name"="Build Harness"
@@ -47,7 +47,7 @@ RUN curl -sSL https://raw.githubusercontent.com/terraform-linters/tflint/master/
 COPY <<EOF /root/.tflint.hcl
 plugin "aws" {
     enabled = true
-    version = "0.23.0"
+    version = "0.26.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 EOF

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Here are some real world examples:
 ```text
 Available targets:
 
+  .PHONY                              Login into docker hub
   aws/install                         Install aws cli bundle
   aws/shell                           Start a aws-vault shell with access to aws api
   bash/lint                           Lint all bash scripts
@@ -180,7 +181,6 @@ Available targets:
   docker/image/promote/local          Promote $SOURCE_DOCKER_REGISTRY/$IMAGE_NAME:$SOURCE_VERSION to $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
   docker/image/promote/remote         Pull $SOURCE_DOCKER_REGISTRY/$IMAGE_NAME:$SOURCE_VERSION and promote to $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
   docker/image/push                   Push $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
-  docker/login                        Login into docker hub
   docs/copyright-add                  Add copyright headers to source code
   docs/github-action.md               Update `docs/github-action.md` from `action.yaml`
   docs/github-actions-reusable-workflows.md Update `docs/github-actions-reusable-workflows.md` from `.github/workflows/*.yaml`

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -3,6 +3,7 @@
 ```text
 Available targets:
 
+  .PHONY                              Login into docker hub
   aws/install                         Install aws cli bundle
   aws/shell                           Start a aws-vault shell with access to aws api
   bash/lint                           Lint all bash scripts
@@ -41,7 +42,6 @@ Available targets:
   docker/image/promote/local          Promote $SOURCE_DOCKER_REGISTRY/$IMAGE_NAME:$SOURCE_VERSION to $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
   docker/image/promote/remote         Pull $SOURCE_DOCKER_REGISTRY/$IMAGE_NAME:$SOURCE_VERSION and promote to $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
   docker/image/push                   Push $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
-  docker/login                        Login into docker hub
   docs/copyright-add                  Add copyright headers to source code
   docs/github-action.md               Update `docs/github-action.md` from `action.yaml`
   docs/github-actions-reusable-workflows.md Update `docs/github-actions-reusable-workflows.md` from `.github/workflows/*.yaml`

--- a/modules/docker/Makefile
+++ b/modules/docker/Makefile
@@ -1,7 +1,7 @@
-DOCKER ?= $(shell which docker)
+DOCKER ?= docker
 
-DOCKER_RUN ?= docker run -i --rm --network=$(DOCKER_NETWORK)
-DOCKER_EXEC ?= $(DOCKER) exec -it
+DOCKER_RUN ?= "$(DOCKER)" run -i --rm --network=$(DOCKER_NETWORK)
+DOCKER_EXEC ?= "$(DOCKER)" exec -it
 CONTAINER_SHELL ?= sh
 
 # It's like ssh for docker

--- a/modules/docker/Makefile.build
+++ b/modules/docker/Makefile.build
@@ -5,8 +5,10 @@ DOCKER_BUILD_FLAGS ?= --no-cache
 DOCKER_IMAGE_NAME ?= tests
 DOCKER_FILE ?= ./Dockerfile
 
+.PHONY: docker/build docker/image/promote/local docker/image/promote/remote docker/image/push
+
 ## Build docker image
-docker/build: $(DOCKER)
+docker/build:
 	$(call assert-set,DOCKER)
 	$(call assert-set,DOCKER_IMAGE_NAME)
 ifeq ($(TRAVIS),true)
@@ -16,7 +18,7 @@ endif
 		printf -- '--build-arg %s=%s ' "$$arg" "$${!arg}"; \
 	done`; \
 	echo "Building $(DOCKER_IMAGE_NAME) from $(DOCKER_FILE) with [$(DOCKER_BUILD_FLAGS)] build args..."; \
-	$(DOCKER) build $(DOCKER_BUILD_FLAGS) $$BUILD_ARGS -t $(DOCKER_IMAGE_NAME) -f $(DOCKER_FILE) $(DOCKER_BUILD_PATH)
+	"$(DOCKER)" build $(DOCKER_BUILD_FLAGS) $$BUILD_ARGS -t $(DOCKER_IMAGE_NAME) -f $(DOCKER_FILE) $(DOCKER_BUILD_PATH)
 
 
 ## Promote $SOURCE_DOCKER_REGISTRY/$IMAGE_NAME:$SOURCE_VERSION to $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
@@ -27,7 +29,7 @@ docker/image/promote/local:
 	$(call assert-set,SOURCE_VERSION)
 	$(call assert-set,TARGET_DOCKER_REGISTRY)
 	$(call assert-set,TARGET_VERSION)
-	@$(DOCKER) tag $(SOURCE_DOCKER_REGISTRY)/$(IMAGE_NAME):$(SOURCE_VERSION) $(TARGET_DOCKER_REGISTRY)/$(IMAGE_NAME):$(TARGET_VERSION)
+	@"$(DOCKER)" tag $(SOURCE_DOCKER_REGISTRY)/$(IMAGE_NAME):$(SOURCE_VERSION) $(TARGET_DOCKER_REGISTRY)/$(IMAGE_NAME):$(TARGET_VERSION)
 
 ## Pull $SOURCE_DOCKER_REGISTRY/$IMAGE_NAME:$SOURCE_VERSION and promote to $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
 docker/image/promote/remote:
@@ -35,7 +37,7 @@ docker/image/promote/remote:
 	$(call assert-set,IMAGE_NAME)
 	$(call assert-set,SOURCE_DOCKER_REGISTRY)
 	$(call assert-set,SOURCE_VERSION)
-	@$(DOCKER) pull $(SOURCE_DOCKER_REGISTRY)/$(IMAGE_NAME):$(SOURCE_VERSION)
+	@"$(DOCKER)" pull $(SOURCE_DOCKER_REGISTRY)/$(IMAGE_NAME):$(SOURCE_VERSION)
 	@$(SELF) -s docker/image/promote/local
 
 ## Push $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
@@ -44,4 +46,4 @@ docker/image/push:
 	$(call assert-set,IMAGE_NAME)
 	$(call assert-set,TARGET_DOCKER_REGISTRY)
 	$(call assert-set,TARGET_VERSION)
-	$(DOCKER) push $(TARGET_DOCKER_REGISTRY)/$(IMAGE_NAME):$(TARGET_VERSION)
+	"$(DOCKER)" push $(TARGET_DOCKER_REGISTRY)/$(IMAGE_NAME):$(TARGET_VERSION)

--- a/modules/docker/Makefile.hub
+++ b/modules/docker/Makefile.hub
@@ -4,7 +4,7 @@
 
 docker/login:
 	@if [ -n "$(DOCKER_HUB_USERNAME)" ] && [ -n "$(DOCKER_HUB_PASSWORD)" ]; then \
-      "$(DOCKER)" login --username="$(DOCKER_HUB_USERNAME)" --password="$(DOCKER_HUB_PASSWORD)"; \
+		"$(DOCKER)" login --username="$(DOCKER_HUB_USERNAME)" --password="$(DOCKER_HUB_PASSWORD)"; \
 	else \
-	  echo "Skipping docker:login. Docker credentials (DOCKER_HUB_USERNAME or DOCKER_HUB_PASSWORD) are not set"; \
+		echo "Skipping docker:login. Docker credentials (DOCKER_HUB_USERNAME or DOCKER_HUB_PASSWORD) are not set"; \
 	fi;

--- a/modules/docker/Makefile.hub
+++ b/modules/docker/Makefile.hub
@@ -1,8 +1,10 @@
 ## Use DOCKER_HUB_USERNAME and DOCKER_HUB_PASSWORD env variables to pass credentials
 ## Login into docker hub
-docker/login: $(DOCKER)
+.PHONY: docker/login
+
+docker/login:
 	@if [ -n "$(DOCKER_HUB_USERNAME)" ] && [ -n "$(DOCKER_HUB_PASSWORD)" ]; then \
-      $(DOCKER) login --username="$(DOCKER_HUB_USERNAME)" --password="$(DOCKER_HUB_PASSWORD)"; \
+      "$(DOCKER)" login --username="$(DOCKER_HUB_USERNAME)" --password="$(DOCKER_HUB_PASSWORD)"; \
 	else \
 	  echo "Skipping docker:login. Docker credentials (DOCKER_HUB_USERNAME or DOCKER_HUB_PASSWORD) are not set"; \
 	fi;


### PR DESCRIPTION
## what

- Handle the case where the path to the `docker` command has a space in it
- Update dependencies
   - Alpine 3.17 -> 3.18
   - Go 1.20.4 -> 1.20.7
   - `tflint` [AWS ruleset](https://github.com/terraform-linters/tflint-ruleset-aws) 0.23.0 -> 0.26.0
   - Python packages:
      - cryptography 41.0.2 -> 41.0.3
      - awscli 1.29.9 -> 1.29.25
      - boto3 1.28.9 -> 1.28.25
      - PyGithub 1.59 -> 1.59.1
   - `lint.yml` workflow:
      - cloudposse/build-harness 1.8.0 -> latest
      - actions/checkout v2 -> v3
      - github/super-linter/slim v4 -> v5


## why

- On macOS, some standard directories (e.g. "Application Support") have spaces in them
- Keep current with security patches and bug fixes

## references

- Fixes #356

Note that `make`, and therefore `build-harness`, does not generally support spaces in path names. In particular, `build-harness` will not be extended to support spaces in the path to the `build-harness` installation or the current working directory. 