### PR TITLE
README Template Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,27 +564,11 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
-<!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Nuru][Nuru_avatar]][Nuru_homepage]<br/>[Nuru][Nuru_homepage] | [![Sarkis][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis][sarkis_homepage] | [![Alexander Babai][alebabai_avatar]][alebabai_homepage]<br/>[Alexander Babai][alebabai_homepage] | [![Jon Boulle][jonboulle_avatar]][jonboulle_homepage]<br/>[Jon Boulle][jonboulle_homepage] | [![Marcin Brański][3h4x_avatar]][3h4x_homepage]<br/>[Marcin Brański][3h4x_homepage] |
-|---|---|---|---|---|---|---|---|
-<!-- markdownlint-restore -->
+Many thanks to our wonderful contributors:
 
-  [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
-  [goruha_homepage]: https://github.com/goruha
-  [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
-  [aknysh_homepage]: https://github.com/aknysh
-  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
-  [Nuru_homepage]: https://github.com/Nuru
-  [Nuru_avatar]: https://img.cloudposse.com/150x150/https://github.com/Nuru.png
-  [sarkis_homepage]: https://github.com/sarkis
-  [sarkis_avatar]: https://img.cloudposse.com/150x150/https://github.com/sarkis.png
-  [alebabai_homepage]: https://github.com/alebabai
-  [alebabai_avatar]: https://img.cloudposse.com/150x150/https://github.com/alebabai.png
-  [jonboulle_homepage]: https://github.com/jonboulle
-  [jonboulle_avatar]: https://img.cloudposse.com/150x150/https://github.com/jonboulle.png
-  [3h4x_homepage]: https://github.com/3h4x
-  [3h4x_avatar]: https://img.cloudposse.com/150x150/https://github.com/3h4x.png
+<a href="https://github.com/cloudposse/build-harness/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=cloudposse/build-harness&max=24" />
+</a>
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -562,13 +562,14 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 
 
-### Contributors
+### ✨ Contributors
 
-<!-- markdownlint-disable -->
-| 
-|
-<!-- markdownlint-restore -->
+This project is under active development, and we encourage contributions from our community. 
+Many thanks to our outstanding contributors:
 
+<a href="https://github.com/cloudposse/build-harness/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=cloudposse/build-harness&max=24" />
+</a>
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -564,11 +564,27 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
-Many thanks to our wonderful contributors:
+<!-- markdownlint-disable -->
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Nuru][Nuru_avatar]][Nuru_homepage]<br/>[Nuru][Nuru_homepage] | [![Sarkis][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis][sarkis_homepage] | [![Alexander Babai][alebabai_avatar]][alebabai_homepage]<br/>[Alexander Babai][alebabai_homepage] | [![Jon Boulle][jonboulle_avatar]][jonboulle_homepage]<br/>[Jon Boulle][jonboulle_homepage] | [![Marcin Brański][3h4x_avatar]][3h4x_homepage]<br/>[Marcin Brański][3h4x_homepage] |
+|---|---|---|---|---|---|---|---|
+<!-- markdownlint-restore -->
 
-<a href="https://github.com/cloudposse/build-harness/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=cloudposse/build-harness&max=24" />
-</a>
+  [osterman_homepage]: https://github.com/osterman
+  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
+  [goruha_homepage]: https://github.com/goruha
+  [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
+  [aknysh_homepage]: https://github.com/aknysh
+  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
+  [Nuru_homepage]: https://github.com/Nuru
+  [Nuru_avatar]: https://img.cloudposse.com/150x150/https://github.com/Nuru.png
+  [sarkis_homepage]: https://github.com/sarkis
+  [sarkis_avatar]: https://img.cloudposse.com/150x150/https://github.com/sarkis.png
+  [alebabai_homepage]: https://github.com/alebabai
+  [alebabai_avatar]: https://img.cloudposse.com/150x150/https://github.com/alebabai.png
+  [jonboulle_homepage]: https://github.com/jonboulle
+  [jonboulle_avatar]: https://img.cloudposse.com/150x150/https://github.com/jonboulle.png
+  [3h4x_homepage]: https://github.com/3h4x
+  [3h4x_avatar]: https://img.cloudposse.com/150x150/https://github.com/3h4x.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -562,14 +562,13 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 
 
-### ✨ Contributors
+### Contributors
 
-This project is under active development, and we encourage contributions from our community. 
-Many thanks to our outstanding contributors:
+<!-- markdownlint-disable -->
+| 
+|
+<!-- markdownlint-restore -->
 
-<a href="https://github.com/cloudposse/build-harness/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=cloudposse/build-harness&max=24" />
-</a>
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -564,11 +564,11 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
-Many thanks to our wonderful contributors:
+<!-- markdownlint-disable -->
+| 
+|
+<!-- markdownlint-restore -->
 
-<a href="https://github.com/cloudposse/build-harness/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=cloudposse/build-harness&max=24" />
-</a>
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -139,4 +139,4 @@ include:
   - "docs/git-io-deprecation.md"
 
 # Include contributors to this project
-contributors:
+contributors: []

--- a/README.yaml
+++ b/README.yaml
@@ -138,21 +138,5 @@ include:
   - "docs/auto-init.md"
   - "docs/git-io-deprecation.md"
 
-# Contributors to this project
+# Include contributors to this project
 contributors:
-  - name: "Erik Osterman"
-    github: "osterman"
-  - name: "Igor Rodionov"
-    github: "goruha"
-  - name: "Andriy Knysh"
-    github: "aknysh"
-  - name: "Nuru"
-    github: "Nuru"
-  - name: "Sarkis"
-    github: "sarkis"
-  - name: "Alexander Babai"
-    github: "alebabai"
-  - name: "Jon Boulle"
-    github: "jonboulle"
-  - name: "Marcin Brański"
-    github: "3h4x"

--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -422,7 +422,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 {{ if has (datasource "config") "contributors" }}
 ### Contributors
 
-Many thanks to our wonderful contributors:
+This project is under active development, and we encourage contributions from our community. 
+Many thanks to our outstanding contributors:
 
 <a href="https://github.com/{{ printf "%s" (ds "config").github_repo}}/graphs/contributors">
   <img src="https://contrib.rocks/image?repo={{ printf "%s" (ds "config").github_repo}}&max=24" />

--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -422,22 +422,12 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 {{ if has (datasource "config") "contributors" }}
 ### Contributors
 
-<!-- markdownlint-disable -->
-| {{ range $contributor := (ds "config").contributors }}{{ printf " [![%s][%s_avatar]][%s_homepage]<br/>[%s][%s_homepage] |" $contributor.name $contributor.github $contributor.github $contributor.name $contributor.github}}{{ end }}
-|{{- range $contributor := (ds "config").contributors -}}---|{{ end }}
-<!-- markdownlint-restore -->
+Many thanks to our wonderful contributors:
 
-{{ range $contributor := (ds "config").contributors -}}
-{{- if has $contributor "homepage" }}
-{{ printf "  [%s_homepage]: %s" $contributor.github $contributor.homepage }}
-{{ else -}}
-{{ printf "  [%s_homepage]: https://github.com/%s" $contributor.github $contributor.github }}
-{{ end -}}
-{{ if has $contributor "avatar" }}{{ printf "  [%s_avatar]: %s" $contributor.github $contributor.avatar }}
-{{ else -}}
-{{ printf "  [%s_avatar]: https://img.cloudposse.com/150x150/https://github.com/%s.png" $contributor.github $contributor.github }}
-{{- end }}
-{{ end }}
+<a href="https://github.com/{{ printf "%s" (ds "config").github_repo}}/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo={{ printf "%s" (ds "config").github_repo}}&max=24" />
+</a>
+
 {{ end }}
 
 {{- $utm_link := printf "%%s?utm_source=%s&utm_medium=%s&utm_campaign=%s&utm_content=%s" "github" "readme" (ds "config").github_repo "%s" -}}

--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -420,7 +420,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 
 {{ if has (datasource "config") "contributors" }}
-### Contributors
+### ✨ Contributors
 
 This project is under active development, and we encourage contributions from our community. 
 Many thanks to our outstanding contributors:

--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -71,12 +71,6 @@ We literally have [*hundreds of other terraform modules*][terraform_modules] tha
 ---
 
 This project {{ if $deprecated }}was{{ else }}is{{ end }} part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
-[<img align="right" title="Share via Email" src="https://docs.cloudposse.com/images/ionicons/ios-email-outline-2.0.1-16x16-999999.svg"/>][share_email]
-[<img align="right" title="Share on Google+" src="https://docs.cloudposse.com/images/ionicons/social-googleplus-outline-2.0.1-16x16-999999.svg" />][share_googleplus]
-[<img align="right" title="Share on Facebook" src="https://docs.cloudposse.com/images/ionicons/social-facebook-outline-2.0.1-16x16-999999.svg" />][share_facebook]
-[<img align="right" title="Share on Reddit" src="https://docs.cloudposse.com/images/ionicons/social-reddit-outline-2.0.1-16x16-999999.svg" />][share_reddit]
-[<img align="right" title="Share on LinkedIn" src="https://docs.cloudposse.com/images/ionicons/social-linkedin-outline-2.0.1-16x16-999999.svg" />][share_linkedin]
-[<img align="right" title="Share on Twitter" src="https://docs.cloudposse.com/images/ionicons/social-twitter-outline-2.0.1-16x16-999999.svg" />][share_twitter]
 
 {{ if (file.Exists "main.tf") }}
 [![Terraform Open Source Modules](https://docs.cloudposse.com/images/terraform-open-source-modules.svg)][terraform_modules]
@@ -181,8 +175,6 @@ systematic way so that they do not catch you by surprise.
 
 Like this project? Please give it a ★ on [our GitHub]({{ printf "https://github.com/%s" (ds "config").github_repo}})! (it helps us **a lot**)
 
-Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
-
 {{ end }}
 {{ if has (ds "config") "related" }}
 ## Related Projects
@@ -236,10 +228,6 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 
 Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
 
-## Discourse Forums
-
-Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
-
 ## Newsletter
 
 Sign up for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover.
@@ -251,7 +239,18 @@ Sign up for [our newsletter][newsletter] that covers everything on our technolog
 [![zoom](https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png")][office_hours]
 
 {{ if not $deprecated -}}
-## Contributing
+## ✨ Contributing
+
+{{ if has (datasource "config") "contributors" }}
+
+This project is under active development, and we encourage contributions from our community. 
+Many thanks to our outstanding contributors:
+
+<a href="https://github.com/{{ printf "%s" (ds "config").github_repo}}/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo={{ printf "%s" (ds "config").github_repo}}&max=24" />
+</a>
+
+{{ end }}
 
 ### Bug Reports & Feature Requests
 
@@ -419,18 +418,6 @@ We offer [paid support][commercial_support] on all of our projects.
 Check out [our other projects][github], [follow us on twitter][twitter], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.
 
 
-{{ if has (datasource "config") "contributors" }}
-### ✨ Contributors
-
-This project is under active development, and we encourage contributions from our community. 
-Many thanks to our outstanding contributors:
-
-<a href="https://github.com/{{ printf "%s" (ds "config").github_repo}}/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo={{ printf "%s" (ds "config").github_repo}}&max=24" />
-</a>
-
-{{ end }}
-
 {{- $utm_link := printf "%%s?utm_source=%s&utm_medium=%s&utm_campaign=%s&utm_content=%s" "github" "readme" (ds "config").github_repo "%s" -}}
 
 [![README Footer][readme_footer_img]][readme_footer_link]
@@ -443,12 +430,10 @@ Many thanks to our outstanding contributors:
   [jobs]: {{ printf $utm_link "https://cpco.io/jobs" "jobs" }}
   [hire]: {{ printf $utm_link "https://cpco.io/hire" "hire" }}
   [slack]: {{ printf $utm_link "https://cpco.io/slack" "slack" }}
-  [linkedin]: {{ printf $utm_link "https://cpco.io/linkedin" "linkedin" }}
   [twitter]: {{ printf $utm_link "https://cpco.io/twitter" "twitter" }}
   [testimonial]: {{ printf $utm_link "https://cpco.io/leave-testimonial" "testimonial" }}
   [office_hours]: {{ printf $utm_link "https://cloudposse.com/office-hours" "office_hours" }}
   [newsletter]: {{ printf $utm_link "https://cpco.io/newsletter" "newsletter" }}
-  [discourse]: {{ printf $utm_link "https://ask.sweetops.com/" "discourse" }}
   [email]: {{ printf $utm_link "https://cpco.io/email" "email" }}
   [commercial_support]: {{ printf $utm_link "https://cpco.io/commercial-support" "commercial_support" }}
   [we_love_open_source]: {{ printf $utm_link "https://cpco.io/we-love-open-source" "we_love_open_source" }}
@@ -459,11 +444,5 @@ Many thanks to our outstanding contributors:
   [readme_footer_link]: {{ printf $utm_link "https://cloudposse.com/readme/footer/link" "readme_footer_link" }}
   [readme_commercial_support_img]: {{ printf "https://cloudposse.com/readme/commercial-support/img" }}
   [readme_commercial_support_link]: {{ printf $utm_link "https://cloudposse.com/readme/commercial-support/link" "readme_commercial_support_link" }}
-  [share_twitter]: {{ printf "https://twitter.com/intent/tweet/?text=%s&url=https://github.com/%s" ((ds "config").name | regexp.Replace " " "+") (ds "config").github_repo }}
-  [share_linkedin]: {{ printf "https://www.linkedin.com/shareArticle?mini=true&title=%s&url=https://github.com/%s" ((ds "config").name | regexp.Replace " " "+") (ds "config").github_repo }}
-  [share_reddit]: {{ printf "https://reddit.com/submit/?url=https://github.com/%s" (ds "config").github_repo }}
-  [share_facebook]: {{ printf "https://facebook.com/sharer/sharer.php?u=https://github.com/%s" (ds "config").github_repo }}
-  [share_googleplus]: {{ printf "https://plus.google.com/share?url=https://github.com/%s" (ds "config").github_repo }}
-  [share_email]: {{ printf "mailto:?subject=%s&body=https://github.com/%s" ((ds "config").name | regexp.Replace " " "+") (ds "config").github_repo }}
   [beacon]: {{ printf "https://ga-beacon.cloudposse.com/UA-76589703-4/%s?pixel&cs=github&cm=readme&an=%s" (ds "config").github_repo (filepath.Base ((ds "config").github_repo)) }}
 <!-- markdownlint-restore -->


### PR DESCRIPTION
## what
- Replaced Contributors with contrib.rocks contributors block
- Removed social links and discourse
- Clean up unnecessary content

## why
- Automatically keep contributors up-to-date
- Our contributors are gravely out of date
- It helps to showcase the popularity of a repo
- Keeping README up-to-date with latest conventions/recommendations

## references
- Internal discussion: https://github.com/cloudposse/knowledge-base/discussions/161
