### PR TITLE
Warning for make version

### DIFF
--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -67,6 +67,7 @@ endef
 .PHONY : init
 ## Init build-harness
 init::
+	if ! make --version | grep -q "GNU Make 4.4"; then echo "GNU Make 4.4 or higher is required. Please upgrade."; fi
 	@ $(harness_install)
 
 .PHONY : clean

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -67,7 +67,7 @@ endef
 .PHONY : init
 ## Init build-harness
 init::
-	if ! make --version | grep -q "GNU Make 4.4"; then echo "GNU Make 4.4 or higher is required. Please upgrade."; fi
+	if ! make --version | grep -q "GNU Make 4.4"; then echo "GNU Make 4.4 is required. Please upgrade."; fi
 	@ $(harness_install)
 
 .PHONY : clean

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -67,7 +67,7 @@ endef
 .PHONY : init
 ## Init build-harness
 init::
-	if ! make --version | grep -q "GNU Make 4.4"; then echo "GNU Make 4.4 is required. Please upgrade."; fi
+	if ! make --version | grep -q "GNU Make 4.4"; then echo "GNU Make 4.4 is required. Please upgrade. For MacOS users it's 'brew install make'."; fi
 	@ $(harness_install)
 
 .PHONY : clean


### PR DESCRIPTION
## what
Warn on make version mismatch
It's just a warning message, intentionally not adding exit 1 to see how it goes. 

## why
We've had numerous issues with built-in macos make. Let's warn users if their version doesn't match what we expect

