### PR TITLE
Move screenshots above banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@
 This `build-harness` is a collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more.
 It's designed to work with CI/CD systems such as GitHub Actions.
 
+## Screenshots
+
+
+![demo](docs/demo.gif?raw=true)
+*Example of using the `build-harness` to build a docker image*
+
 ---
 > [!NOTE]
 > This project is part of Cloud Posse's comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
@@ -36,14 +42,6 @@ It's designed to work with CI/CD systems such as GitHub Actions.
 >
 
 [![README Header][readme_header_img]][readme_header_link]
-
-
-
-## Screenshots
-
-
-![demo](docs/demo.gif?raw=true)
-*Example of using the `build-harness` to build a docker image*
 
 
 
@@ -416,7 +414,7 @@ under the License.
 All other trademarks referenced herein are the property of their respective owners.
 ## Copyrights
 
-Copyright © 2016-2023 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2016-2024 [Cloud Posse, LLC](https://cloudposse.com)
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -65,6 +65,12 @@ We literally have [*hundreds of other terraform modules*][terraform_modules] tha
 
 {{- end }}
 {{- end }}
+{{ if has (ds "config") "screenshots" }}
+## Screenshots
+
+{{ range $screenshot := (ds "config").screenshots }}
+{{ printf "![%s](%s)\n*%s*" $screenshot.name $screenshot.url $screenshot.description }}{{ end }}
+{{- end }}
 
 ---
 > [!NOTE]
@@ -99,13 +105,6 @@ We literally have [*hundreds of other terraform modules*][terraform_modules] tha
 [![README Header][readme_header_img]][readme_header_link]
 {{- end }}
 
-
-{{ if has (ds "config") "screenshots" }}
-## Screenshots
-
-{{ range $screenshot := (ds "config").screenshots }}
-{{ printf "![%s](%s)\n*%s*" $screenshot.name $screenshot.url $screenshot.description }}{{ end }}
-{{- end }}
 {{- end }}
 
 {{ if has (ds "config") "introduction" }}


### PR DESCRIPTION
## what
* Move screenshots above banners <img width="936" alt="image" src="https://github.com/cloudposse/build-harness/assets/52489/366b3375-62a8-4ee2-bbf8-7577aa13b744">


## why
* Move more important things above the fold

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
