### PR TITLE
Remove warning about Gnu `make` version

### DIFF
--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -67,7 +67,6 @@ endef
 .PHONY : init
 ## Init build-harness
 init::
-	if ! make --version | grep -q "GNU Make 4.4"; then echo "GNU Make 4.4 is required. Please upgrade. For MacOS users it's 'brew install make'."; fi
 	@ $(harness_install)
 
 .PHONY : clean


### PR DESCRIPTION
## what

- Remove warning about Gnu `make` version added in #360 

## why

- The warning was unnecessary, misleading, and overly specific
  - The warning checked for "GNU Make 4.4". This of course will break when version 4.5 comes out. Furthermore, Ubuntu 20.4 LTS currently has GNU Make 4.2, which also triggers the warnings
  - The issues with building on macOS that were purported to be fixed by using GNU Make have not been clearly connected to the `make` version. I strongly suspect any issues with builds on Mac to be related to such things as macOS shipping with the ancient `bash` version 3.2.57, which is missing important features available in the current `bash` v5, or other aspects of macOS deviations from POSIX. These should be addressed by fixing the broken build recipes, not by requiring action on the part of the user (unless action is required, like installing `jq`, in which case this should cause an explicit and specific error message to be generated.

