### PR TITLE
Restore README_INCLUDES

### DIFF
--- a/modules/readme/Makefile
+++ b/modules/readme/Makefile
@@ -2,6 +2,9 @@ export README_LINT ?= $(TMP)/README.md
 export README_FILE ?= README.md
 export README_YAML ?= README.yaml
 
+# Needed by README.md.gotmpl for `includes` to function
+export README_INCLUDES ?= $(file://$(shell pwd)/?type=text/plain)
+
 export README_TEMPLATE_REPO_REMOTE_NAME ?= origin
 export README_TEMPLATE_REPO_REMOTE ?= $(shell [ -d .git ] && git remote get-url $(README_TEMPLATE_REPO_REMOTE_NAME))
 


### PR DESCRIPTION
## what
- Restore `README_INCLUDES`

## why
- #368 accidentally removed this, which is needed by the [`README.md.gotmpl`](https://github.com/cloudposse/.github/blob/main/README.md.gotmpl#L2)