### PR TITLE
Consolidate auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -9,16 +9,8 @@ jobs:
   semver:
     runs-on: ubuntu-latest
     steps:
-    # Get PR from merged commit to master
-    - uses: actions-ecosystem/action-get-merged-pull-request@v1
-      id: get-merged-pull-request
-      with:
-        github_token: ${{ secrets.REPO_ACCESS_TOKEN }}
-    # Drafts your next Release notes as Pull Requests are merged into "master"
-    - uses: release-drafter/release-drafter@v5
-      with:
-        publish: ${{ !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
-        prerelease: false
-        config-name: auto-release.yml
-      env:
-        GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+      - uses: cloudposse/github-action-auto-release@v1
+        with:
+          prerelease: false
+          publish: true
+          config-name: auto-release.yml

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 [![README Commercial Support][readme_commercial_support_img]][readme_commercial_support_link]
 ## License
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge)](https://opensource.org/licenses/Apache-2.0)
 
 See [LICENSE](LICENSE) for full details.
 


### PR DESCRIPTION
## what
* Use `cloudposse/github-action-auto-release` in `auto-release.yaml` workflow

## why
* Solve old nodejs warning
* Reduce duplication of code
