### PR TITLE
Fix detection of github organization for README templates

### DIFF
--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -16,7 +16,7 @@ jobs:
     # However, using a personal access token will cause events to be triggered.
     # We need that to ensure a status gets posted after the auto-format commit.
     # We also want to trigger tests if the auto-format made no changes.
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       if: github.event.pull_request.state == 'open'
       name: Privileged Checkout
       with:

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -7,9 +7,9 @@ jobs:
   default:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: "Handle common commands"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.33.0
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout commit"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Run tests"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.33.0
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - shell: bash
-        run: /usr/bin/make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true readme/lint
+        run: /usr/bin/make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true git-safe-directory readme/lint
 
   super-linter:
     name: superlinter

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
   lint-readme:
     name: readme
     runs-on: ubuntu-latest
-    container: cloudposse/build-harness:pr-374-merge
+    container: cloudposse/build-harness:latest
     steps:
       - uses: actions/checkout@v4
       - shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
   lint-readme:
     name: readme
     runs-on: ubuntu-latest
-    container: cloudposse/build-harness:latest
+    container: cloudposse/build-harness:pr-374-merge
     steps:
       - uses: actions/checkout@v4
       - shell: bash

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout source code at current commit"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+      # Waiting to update codeowners-validator until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 -->
 
-This `build-harness` is a collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more.
+This `build-harness` is a collection of Makefiles to facilitate building READMEs, Golang projects, Dockerfiles, Helm charts, and more.
 It's designed to work with CI/CD systems such as GitHub Actions.
 
 ## Screenshots

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- markdownlint-disable -->
 [![Project Banner](.github/banner.png?raw=true)](https://cpco.io/homepage)
- [![Build Status](https://img.shields.io/github/actions/workflow/status/cloudposse/build-harness/docker.yml?style=for-the-badge)](https://github.com/cloudposse/build-harness/actions/workflows/docker.yml) [![Latest Release](https://img.shields.io/github/release/cloudposse/build-harness.svg?style=for-the-badge)](https://github.com/cloudposse/build-harness/releases/latest) [![Last Updated](https://img.shields.io/github/last-commit/cloudposse/build-harness/main?style=for-the-badge)](https://github.com/cloudposse/build-harness/commits/main/) [![Slack Community](https://slack.cloudposse.com/for-the-badge.svg)](https://slack.cloudposse.com)
+ [![Build Status](https://img.shields.io/github/actions/workflow/status/cloudposse/build-harness/docker.yml?style=for-the-badge)](https://github.com/cloudposse/build-harness/actions/workflows/docker.yml) [![Latest Release](https://img.shields.io/github/release/cloudposse/build-harness.svg?style=for-the-badge)](https://github.com/cloudposse/build-harness/releases/latest) [![Last Updated](https://img.shields.io/github/last-commit/cloudposse/build-harness/master?style=for-the-badge)](https://github.com/cloudposse/build-harness/commits/master/) [![Slack Community](https://slack.cloudposse.com/for-the-badge.svg)](https://slack.cloudposse.com)
 <!-- markdownlint-restore -->
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- markdownlint-disable -->
 [![Project Banner](.github/banner.png?raw=true)](https://cpco.io/homepage)
- [![Build Status](https://github.com/cloudposse/build-harness/workflows/docker/badge.svg?branch=master)](https://github.com/cloudposse/build-harness/actions?query=workflow%3Adocker) [![Latest Release](https://img.shields.io/github/release/cloudposse/build-harness.svg)](https://github.com/cloudposse/build-harness/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+ [![Build Status](https://img.shields.io/github/actions/workflow/status/cloudposse/build-harness/docker.yml?style=for-the-badge)](https://github.com/cloudposse/build-harness/actions/workflows/docker.yml) [![Latest Release](https://img.shields.io/github/release/cloudposse/build-harness.svg?style=for-the-badge)](https://github.com/cloudposse/build-harness/releases/latest) [![Last Updated](https://img.shields.io/github/last-commit/cloudposse/build-harness/main?style=for-the-badge)](https://github.com/cloudposse/build-harness/commits/main/) [![Slack Community](https://slack.cloudposse.com/for-the-badge.svg)](https://slack.cloudposse.com)
 <!-- markdownlint-restore -->
 
 
@@ -387,7 +387,7 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 [![README Commercial Support][readme_commercial_support_img]][readme_commercial_support_link]
 ## License
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge)](https://opensource.org/licenses/Apache-2.0)
 
 See [LICENSE](LICENSE) for full details.
 

--- a/README.yaml
+++ b/README.yaml
@@ -30,8 +30,8 @@ badges:
     image: "https://img.shields.io/github/release/cloudposse/build-harness.svg?style=for-the-badge"
     url: "https://github.com/cloudposse/build-harness/releases/latest"
   - name: "Last Updated"
-    image: https://img.shields.io/github/last-commit/cloudposse/build-harness/main?style=for-the-badge
-    url: https://github.com/cloudposse/build-harness/commits/main/
+    image: https://img.shields.io/github/last-commit/cloudposse/build-harness/master?style=for-the-badge
+    url: https://github.com/cloudposse/build-harness/commits/master/
   - name: "Slack Community"
     image: "https://slack.cloudposse.com/for-the-badge.svg"
     url: "https://slack.cloudposse.com"

--- a/README.yaml
+++ b/README.yaml
@@ -24,13 +24,16 @@ github_repo: cloudposse/build-harness
 # Badges to display
 badges:
   - name: "Build Status"
-    image: "https://github.com/cloudposse/build-harness/workflows/docker/badge.svg?branch=master"
-    url: "https://github.com/cloudposse/build-harness/actions?query=workflow%3Adocker"
+    image: "https://img.shields.io/github/actions/workflow/status/cloudposse/build-harness/docker.yml?style=for-the-badge"
+    url: "https://github.com/cloudposse/build-harness/actions/workflows/docker.yml"
   - name: "Latest Release"
-    image: "https://img.shields.io/github/release/cloudposse/build-harness.svg"
+    image: "https://img.shields.io/github/release/cloudposse/build-harness.svg?style=for-the-badge"
     url: "https://github.com/cloudposse/build-harness/releases/latest"
+  - name: "Last Updated"
+    image: https://img.shields.io/github/last-commit/cloudposse/build-harness/main?style=for-the-badge
+    url: https://github.com/cloudposse/build-harness/commits/main/
   - name: "Slack Community"
-    image: "https://slack.cloudposse.com/badge.svg"
+    image: "https://slack.cloudposse.com/for-the-badge.svg"
     url: "https://slack.cloudposse.com"
 
 related:

--- a/README.yaml
+++ b/README.yaml
@@ -58,7 +58,7 @@ screenshots:
 
 # Short description of this project
 description: |-
-  This `build-harness` is a collection of Makefiles to facilitate building Golang projects, Dockerfiles, Helm charts, and more.
+  This `build-harness` is a collection of Makefiles to facilitate building READMEs, Golang projects, Dockerfiles, Helm charts, and more.
   It's designed to work with CI/CD systems such as GitHub Actions.
   
 # Introduction to the project

--- a/modules/readme/Makefile
+++ b/modules/readme/Makefile
@@ -2,25 +2,11 @@ export README_LINT ?= $(TMP)/README.md
 export README_FILE ?= README.md
 export README_YAML ?= README.yaml
 
-export README_TEMPLATE_REPO_REMOTE_NAME ?= origin
-export README_TEMPLATE_REPO_REMOTE ?= $(shell [ -d .git ] && git remote get-url $(README_TEMPLATE_REPO_REMOTE_NAME))
-
-# Parse https://github.com/...
-ifneq (,$(findstring https://github.com/,$(README_TEMPLATE_REPO_REMOTE)))
-URL_NO_PROTOCOL := $(subst https://github.com/,,$(README_TEMPLATE_REPO_REMOTE))
-export README_TEMPLATE_REPO_ORG ?= $(firstword $(subst /, ,$(URL_NO_PROTOCOL)))
-endif
-
-# Parse git@github.com:...
-ifneq (,$(findstring git@github.com:,$(README_TEMPLATE_REPO_REMOTE)))
-URL_NO_GIT := $(subst git@github.com:,,$(README_TEMPLATE_REPO_REMOTE))
-export README_TEMPLATE_REPO_ORG ?= $(firstword $(subst /, ,$(URL_NO_GIT)))
-endif
-
+export README_TEMPLATE_REPO_ORG ?= $(shell [ -f "$(README_YAML)" ] &&  dirname $$(grep '^github_repo: *' "$(README_YAML)" | cut -d: -f2))
 export README_TEMPLATE_REPO ?= .github
 export README_TEMPLATE_REPO_REF ?= main
 export README_TEMPLATE_REPO_PATH ?= README.md.gotmpl
-export README_TEMPLATE_REPO_URL := https://raw.githubusercontent.com/$${README_GITHUB_ORG}/$(README_TEMPLATE_REPO)/$(README_TEMPLATE_REPO_REF)/$(README_TEMPLATE_REPO_PATH)
+export README_TEMPLATE_REPO_URL := https://raw.githubusercontent.com/$(README_TEMPLATE_REPO_ORG)/$(README_TEMPLATE_REPO)/$(README_TEMPLATE_REPO_REF)/$(README_TEMPLATE_REPO_PATH)
 export README_TEMPLATE_FILE ?= $(BUILD_HARNESS_PATH)/templates/README.md.gotmpl
 export README_TEMPLATE_YAML := $(BUILD_HARNESS_PATH)/templates/$(README_YAML)
 
@@ -43,6 +29,7 @@ export README_ALLOWLIST_ORGS := \
 $(README_TEMPLATE_FILE):
 	@for README_GITHUB_ORG in $(README_ALLOWLIST_ORGS); do \
 		if [ "$${README_GITHUB_ORG}" == "$${README_TEMPLATE_REPO_ORG}" ]; then \
+			echo "Fetching README template from $${README_TEMPLATE_REPO_ORG}"; \
 			if curl -o $@ -fsSL "$(README_TEMPLATE_REPO_URL)"; then \
 				exit 0; \
 			else \
@@ -51,7 +38,7 @@ $(README_TEMPLATE_FILE):
 			fi; \
 		fi; \
 	done; \
-	printf "Detected GitHub Org '%s' is not in the list of organizations allowed to provide README templates.\n" "$(README_TEMPLATE_REPO_ORG)" >&2; \
+	printf "Detected GitHub Org '%s' is not in the list of organizations allowed to provide README templates.\n" "$${README_TEMPLATE_REPO_ORG}" >&2; \
 	exit 1
 
 ## Alias for readme/build

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -83,11 +83,22 @@ clean::
 		fi; \
 	fi
 
-.PHONY: safe-directory
+.PHONY: git-safe-directory
 
 # Workaround for https://github.com/actions/checkout/issues/766
-safe-directory:
-	[[ -n "$$GITHUB_WORKSPACE" ]] && git config --global --add safe.directory "$$GITHUB_WORKSPACE" || git config --global --add safe.directory '*'
+# Note that if we always add a safe directory, we are recreating the security problem git is trying to solve.
+# So we only add the safe directory if we are running in a GitHub Actions environment.
+git-safe-directory:
+	@if remove_protection_cmd=$$(git log -1 2>&1 | grep -F 'git config --global --add safe.directory'); then \
+		if [[ -n "$$GITHUB_WORKSPACE" ]]; then \
+			printf "Marking directory %s as safe for git to trust\n" "$$GITHUB_WORKSPACE" >&2; \
+			git config --global --add safe.directory "$$GITHUB_WORKSPACE";  \
+		else \
+			printf "\nGit refused to trust a directory, presumably due to dubious ownership.\n" >&2; \
+			printf "GitHub Actions environment not detected, so script is not automatically trusting suspicious directory.\n\n" >&2 ;\
+			printf "To trust the directory git is concerned about, run:\n\n  %s\n\n" "$$remove_protection_cmd" >&2; \
+		fi \
+	fi
 
 .PHONY: build-harness/shell builder build-harness/shell/pull builder/pull builder/build builder-slim/build
 
@@ -149,7 +160,7 @@ precommit/terraform pr/auto-format precommit/terraform/host pr/auto-format/host:
 pr/readme pr/readme/host: ARGS := readme/deps readme
 pr/github-update pr/github-update/host: ARGS := github/update
 precommit/terraform pr/auto-format pr/readme pr/github-update: build-harness/runner
-precommit/terraform/host pr/auto-format/host pr/readme/host pr/github-update/host: safe-directory
+precommit/terraform/host pr/auto-format/host pr/readme/host pr/github-update/host: git-safe-directgory
 	$(MAKE) $(ARGS)
 
 pr/pre-commit: ARGS := pre-commit/run


### PR DESCRIPTION
## what
* Use the `github_repo` parameter in the `README.yaml` to determine the organization
* Make git checkout safe for linters to use
* Update uses of `actions/checkout` to v4

## why
* #368 introduce the ability to have readme's sourced from various organizations
* It did not take into account that the `git remotes` for forks will give the organization of the fork
* It's better to use the `README.yaml` to determine the org, but this was not considered in the original implementation
 
## references
- #368
- #371 
- actions/checkout#766