### PR TITLE
Fix make/readme when github_repo has quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 build-harness.iml
 build-harness
 templates/README.md.gotmpl
-node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build-harness.iml
 build-harness
 templates/README.md.gotmpl
+node_modules

--- a/modules/readme/Makefile
+++ b/modules/readme/Makefile
@@ -2,7 +2,7 @@ export README_LINT ?= $(TMP)/README.md
 export README_FILE ?= README.md
 export README_YAML ?= README.yaml
 
-export README_TEMPLATE_REPO_ORG ?= $(shell [ -f "$(README_YAML)" ] &&  dirname $$(grep '^github_repo: *' "$(README_YAML)" | tr -d \\'\\" | cut -d: -f2))
+export README_TEMPLATE_REPO_ORG ?= $(shell [ -f "$(README_YAML)" ] &&  dirname $$(grep '^github_repo: *' "$(README_YAML)" | tr -d \'\" | cut -d: -f2))
 export README_TEMPLATE_REPO ?= .github
 export README_TEMPLATE_REPO_REF ?= main
 export README_TEMPLATE_REPO_PATH ?= README.md.gotmpl

--- a/modules/readme/Makefile
+++ b/modules/readme/Makefile
@@ -2,7 +2,7 @@ export README_LINT ?= $(TMP)/README.md
 export README_FILE ?= README.md
 export README_YAML ?= README.yaml
 
-export README_TEMPLATE_REPO_ORG ?= $(shell [ -f "$(README_YAML)" ] &&  dirname $$(grep '^github_repo: *' "$(README_YAML)" | cut -d: -f2))
+export README_TEMPLATE_REPO_ORG ?= $(shell [ -f "$(README_YAML)" ] &&  dirname $$(grep '^github_repo: *' "$(README_YAML)" | tr -d \\'\\" | cut -d: -f2))
 export README_TEMPLATE_REPO ?= .github
 export README_TEMPLATE_REPO_REF ?= main
 export README_TEMPLATE_REPO_PATH ?= README.md.gotmpl


### PR DESCRIPTION
## what
- Use `tr` to delete quote characters

## why
- repos will never have special shell characters in their name
- it breaks readme generation due to spurious quotes

## references
- #374 (introduced bug)