### PR TITLE
Disambiguate packages install path from other uses of INSTALL_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,9 +76,7 @@ RUN apk --update --no-cache add \
 
 # Use Terraform 1 by default
 ARG DEFAULT_TERRAFORM_VERSION=1
-RUN update-alternatives --set terraform /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform && \
-  mkdir -p /build-harness/vendor && \
-  cp -p /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform /build-harness/vendor/terraform
+RUN update-alternatives --set terraform /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform
 
 # Install tflint
 RUN curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
@@ -102,11 +100,13 @@ RUN v=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r 
 
 COPY ./ /build-harness/
 
-ENV INSTALL_PATH /usr/local/bin
+# Set PACKAGES_PREFER_HOST=true to prevent the build-harness from installing packages
+# from the cloudposse/packages repository as part of the Docker image build process.
+# Any needed packages should be installed in the Dockerfile above here instead.
+ENV PACKAGES_PREFER_HOST=true
 
 WORKDIR /build-harness
 
-ARG PACKAGES_PREFER_HOST=true
 RUN make -s bash/lint make/lint
 RUN make -s template/deps readme/deps
 RUN make -s go/deps-dev

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -38,9 +38,7 @@ RUN sed -i /PATH=/d /etc/profile
 
 # Use Terraform 1 by default
 ARG DEFAULT_TERRAFORM_VERSION=1
-RUN update-alternatives --set terraform /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform && \
-  mkdir -p /build-harness/vendor && \
-  ln -s /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform /build-harness/vendor/terraform
+RUN update-alternatives --set terraform /usr/share/terraform/$DEFAULT_TERRAFORM_VERSION/bin/terraform
 
 # Install tflint
 RUN curl -sSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
@@ -62,11 +60,13 @@ RUN v=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r 
 
 COPY ./ /build-harness/
 
-ENV INSTALL_PATH /usr/local/bin
+# Set PACKAGES_PREFER_HOST=true to prevent the build-harness from installing packages
+# from the cloudposse/packages repository as part of the Docker image build process.
+# Any needed packages should be installed in the Dockerfile above here instead.
+ENV PACKAGES_PREFER_HOST=true
 
 WORKDIR /build-harness
 
-ENV PACKAGES_PREFER_HOST=true
 RUN make -s bash/lint make/lint
 RUN make -s template/deps readme/deps
 

--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,14 @@ ifneq ($(wildcard $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/*/Makefile*),)
 -include $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/*/Makefile*
 endif
 
-# Unless PACKAGES_PREFER_HOST is not "false", add the INSTALL_PATH, which
+# Unless PACKAGES_PREFER_HOST is not "false", add the PACKAGES_INSTALL_PATH, which
 # is where build-harness installs needed tools, to the PATH, but wait
 # until it is set, which may not be the first time through this Makefile.
 # There is an incredibly subtle behavior here. Changes to PATH do not
 # affect `make` itself, so $(shell ...) will not see the new PATH.
 # Even more subtle, simple recipes that do not require a subshell,
 # such as `kubectl version`, will NOT see the new PATH. To use binaries
-# installed in the INSTALL_PATH, you must use a recipe that forces a subshell,
+# installed in the PACKAGES_INSTALL_PATH, you must use a recipe that forces a subshell,
 # such as by using a pipe or compound command, or if nothing else is needed,
 # using a no-op command such as `: && kubectl version`.
 # To make things even more subtle, this is inconsistent across different
@@ -79,8 +79,8 @@ endif
 # See:
 # - https://savannah.gnu.org/bugs/?10593#comment5
 # - https://savannah.gnu.org/bugs/?56834
-ifneq ($(INSTALL_PATH),)
-export PATH := $(if $(subst false,,$(PACKAGES_PREFER_HOST)),$(PATH),$(INSTALL_PATH):$(PATH))
+ifneq ($(PACKAGES_INSTALL_PATH),)
+export PATH := $(if $(subst false,,$(PACKAGES_PREFER_HOST)),$(PATH),$(PACKAGES_INSTALL_PATH):$(PATH))
 endif
 
 # For backwards compatibility with all of our other projects that use build-harness

--- a/README.md
+++ b/README.md
@@ -221,10 +221,10 @@ Available targets:
   init                                Init build-harness
   jenkins/run-job-with-tag            Run a Jenkins Job with $(TAG)
   make/lint                           Lint all makefiles
-  packages/delete                     Delete packages
-  packages/install                    Install packages 
+  packages/delete                     Delete local copy of packages repository
+  packages/install                    Download packages repository
   packages/install/%                  Install package (e.g. helm, helmfile, kubectl)
-  packages/reinstall                  Reinstall packages
+  packages/reinstall                  Reinstall local copy of packages repository
   packages/reinstall/%                Reinstall package (e.g. helm, helmfile, kubectl)
   packages/uninstall/%                Uninstall package (e.g. helm, helmfile, kubectl)
   readme                              Alias for readme/build

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -103,10 +103,10 @@ Available targets:
   init                                Init build-harness
   jenkins/run-job-with-tag            Run a Jenkins Job with $(TAG)
   make/lint                           Lint all makefiles
-  packages/delete                     Delete packages
-  packages/install                    Install packages 
+  packages/delete                     Delete local copy of packages repository
+  packages/install                    Download packages repository
   packages/install/%                  Install package (e.g. helm, helmfile, kubectl)
-  packages/reinstall                  Reinstall packages
+  packages/reinstall                  Reinstall local copy of packages repository
   packages/reinstall/%                Reinstall package (e.g. helm, helmfile, kubectl)
   packages/uninstall/%                Uninstall package (e.g. helm, helmfile, kubectl)
   readme                              Alias for readme/build

--- a/modules/packages/Makefile
+++ b/modules/packages/Makefile
@@ -1,6 +1,6 @@
 export VENDOR_DIR ?= $(BUILD_HARNESS_PATH)/vendor
 export VENDOR_SUBDIR := $(shell uname -s)/$(shell uname -m)
-export INSTALL_PATH ?= $(VENDOR_DIR)/$(VENDOR_SUBDIR)
+export PACKAGES_INSTALL_PATH ?= $(VENDOR_DIR)/$(VENDOR_SUBDIR)
 export PACKAGES_VERSION ?= master
 export PACKAGES_PATH ?= $(VENDOR_DIR)/packages
 # PACKAGES_PREFER_HOST is used to force the use of the host's tools
@@ -9,7 +9,7 @@ export PACKAGES_PATH ?= $(VENDOR_DIR)/packages
 # a compromised version of a tool that would be used by subsequent CI runs.
 export PACKAGES_PREFER_HOST ?= false
 
-## Delete packages
+## Delete local copy of packages repository
 packages/delete:
 	@# Do some checking to guard against running something like `rm -rf /` by mistake.
 	@# Check if packages is a subdirectory of build-harness and is a valid directory before deleting it.
@@ -23,13 +23,13 @@ packages/delete:
 		rm -rf "$(realpath $(PACKAGES_PATH))"; \
 	fi
 
-## Reinstall packages
+## Reinstall local copy of packages repository
 packages/reinstall: packages/delete packages/install
 	@exit 0
 
 # Set PRESERVE_PACKAGES to a non-empty value to preserve the packages cache if it is less than a day old
 packages/install: PRESERVE_PACKAGES ?= $(shell [ -d "$(PACKAGES_PATH)" ] && find "$(PACKAGES_PATH)" -maxdepth 0 -mtime 0)
-## Install packages 
+## Download packages repository
 packages/install: packages/delete
 	@if [ ! -d "$(PACKAGES_PATH)" ]; then \
 		echo "* Installing packages $(PACKAGES_VERSION)..."; \
@@ -38,6 +38,7 @@ packages/install: packages/delete
 	fi 
 
 ## Install package (e.g. helm, helmfile, kubectl)
+packages/install/%: export INSTALL_PATH = $(PACKAGES_INSTALL_PATH)
 packages/install/%:
 	@binary="$*"; \
 	if [ "$(PACKAGES_PREFER_HOST)" = "true" ]; then \
@@ -48,18 +49,20 @@ packages/install/%:
 			echo "* NOT Installing $* because PACKAGES_PREFER_HOST is true" >&2; \
 			exit 1; \
 		fi; \
-	elif [ -x "$(INSTALL_PATH)/$$binary" ]; then \
+	elif [ -x "$(PACKAGES_INSTALL_PATH)/$$binary" ]; then \
 		echo "* Package $$binary already installed"; \
 	else \
 		$(MAKE) packages/install && \
-		echo "* Installing $* to $(INSTALL_PATH)" && \
+		echo "* Installing $* to $(PACKAGES_INSTALL_PATH)" && \
 		$(MAKE) -C $(PACKAGES_PATH)/install "$*"; \
 	fi;
 
 ## Reinstall package (e.g. helm, helmfile, kubectl)
+packages/reinstall/%: export INSTALL_PATH = $(PACKAGES_INSTALL_PATH)
 packages/reinstall/%: packages/install
 	@$(MAKE) -C $(PACKAGES_PATH)/install $(subst packages/reinstall/,,$@)
 
 ## Uninstall package (e.g. helm, helmfile, kubectl)
+packages/uninstall/%: export INSTALL_PATH = $(PACKAGES_INSTALL_PATH)
 packages/uninstall/%: packages/install
 	@$(MAKE) -C $(PACKAGES_PATH)/uninstall $(subst packages/uninstall/,,$@)

--- a/templates/Makefile.build-harness
+++ b/templates/Makefile.build-harness
@@ -188,6 +188,7 @@ build-harness/runner:
 	$(info Starting $(RUNNER_DOCKER_IMAGE):$(RUNNER_DOCKER_TAG))
 	docker run --name build-harness \
 		--rm -it \
+		--platform linux/amd64 \
 		-e PACKAGES_PREFER_HOST=true \
 		$(addprefix -e ,$(DOCKER_ENVS)) \
 		$(MOUNT_HOME) \


### PR DESCRIPTION
## what

- Use `PACKAGES_INSTALL_PATH` instead of `INSTALL_PATH` to determine where `build-harness` installs its tools

## why

- Other Makefiles use `INSTALL_PATH` to determine where to install their build artifacts (typically `/usr/local/bin`) but that does not mean `build-harness` should be installing its tools there

