### PR TITLE
Upgrade go to 1.21.7, terraform to 1.5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.13-alpine3.18
+FROM golang:1.21.7-alpine3.18
 
 LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Here is a real world example:
 ```text
 Available targets:
 
-  .PHONY                              Login into docker hub
   aws/install                         Install aws cli bundle
   aws/shell                           Start a aws-vault shell with access to aws api
   bash/lint                           Lint all bash scripts
@@ -160,6 +159,7 @@ Available targets:
   docker/image/promote/local          Promote $SOURCE_DOCKER_REGISTRY/$IMAGE_NAME:$SOURCE_VERSION to $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
   docker/image/promote/remote         Pull $SOURCE_DOCKER_REGISTRY/$IMAGE_NAME:$SOURCE_VERSION and promote to $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
   docker/image/push                   Push $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
+  docker/login                        Login into docker hub
   docs/copyright-add                  Add copyright headers to source code
   docs/github-action.md               Update `docs/github-action.md` from `action.yaml`
   docs/github-actions-reusable-workflows.md Update `docs/github-actions-reusable-workflows.md` from `.github/workflows/*.yaml`
@@ -402,7 +402,9 @@ Ensure that your team succeeds by using our proven process and turnkey blueprint
 <summary>Preamble to the Apache License, Version 2.0</summary>
 <br/>
 <br/>
+
 Complete license is available in the [`LICENSE`](LICENSE) file.
+
 ```text
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -3,7 +3,6 @@
 ```text
 Available targets:
 
-  .PHONY                              Login into docker hub
   aws/install                         Install aws cli bundle
   aws/shell                           Start a aws-vault shell with access to aws api
   bash/lint                           Lint all bash scripts
@@ -42,6 +41,7 @@ Available targets:
   docker/image/promote/local          Promote $SOURCE_DOCKER_REGISTRY/$IMAGE_NAME:$SOURCE_VERSION to $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
   docker/image/promote/remote         Pull $SOURCE_DOCKER_REGISTRY/$IMAGE_NAME:$SOURCE_VERSION and promote to $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
   docker/image/push                   Push $TARGET_DOCKER_REGISTRY/$IMAGE_NAME:$TARGET_VERSION
+  docker/login                        Login into docker hub
   docs/copyright-add                  Add copyright headers to source code
   docs/github-action.md               Update `docs/github-action.md` from `action.yaml`
   docs/github-actions-reusable-workflows.md Update `docs/github-actions-reusable-workflows.md` from `.github/workflows/*.yaml`

--- a/modules/docker/Makefile.build
+++ b/modules/docker/Makefile.build
@@ -1,7 +1,8 @@
 ## Use DOCKER_IMAGE_NAME envvar to specify docker image with tags
-## User ARGS to pass arguments
+## Use ARGS to pass arguments
 DOCKER_BUILD_PATH ?= .
-DOCKER_BUILD_FLAGS ?= --no-cache
+# Do not set any default value for DOCKER_BUILD_FLAGS, as it is hard to override with nothing
+# DOCKER_BUILD_FLAGS ?= --no-cache
 DOCKER_IMAGE_NAME ?= tests
 DOCKER_FILE ?= ./Dockerfile
 
@@ -17,7 +18,7 @@ endif
 	@BUILD_ARGS=`for arg in $$ARGS; do \
 		printf -- '--build-arg %s=%s ' "$$arg" "$${!arg}"; \
 	done`; \
-	echo "Building $(DOCKER_IMAGE_NAME) from $(DOCKER_FILE) with [$(DOCKER_BUILD_FLAGS)] build args..."; \
+	echo "Building $(DOCKER_IMAGE_NAME) from $(DOCKER_FILE) with opts [$(DOCKER_BUILD_FLAGS)$${BUILD_ARGS:+ $${BUILD_ARGS}}]..."; \
 	"$(DOCKER)" build $(DOCKER_BUILD_FLAGS) $$BUILD_ARGS -t $(DOCKER_IMAGE_NAME) -f $(DOCKER_FILE) $(DOCKER_BUILD_PATH)
 
 

--- a/modules/docker/Makefile.hub
+++ b/modules/docker/Makefile.hub
@@ -1,7 +1,8 @@
 ## Use DOCKER_HUB_USERNAME and DOCKER_HUB_PASSWORD env variables to pass credentials
-## Login into docker hub
+
 .PHONY: docker/login
 
+## Login into docker hub
 docker/login:
 	@if [ -n "$(DOCKER_HUB_USERNAME)" ] && [ -n "$(DOCKER_HUB_PASSWORD)" ]; then \
 		"$(DOCKER)" login --username="$(DOCKER_HUB_USERNAME)" --password="$(DOCKER_HUB_PASSWORD)"; \

--- a/modules/readme/Makefile
+++ b/modules/readme/Makefile
@@ -67,7 +67,7 @@ readme/lint:
 ## Create README.md by building it from README.yaml
 readme/build: readme/deps $(README_TEMPLATE_FILE) $(README_DEPS)
 	@gomplate --file $(README_TEMPLATE_FILE) --out $(README_FILE) --config $(BUILD_HARNESS_PATH)/configs/gomplate.yaml && \
-	echo "Generated $(README_FILE) from $(README_TEMPLATE_FILE) using data from $(README_TEMPLATE_YAML)"
+	echo "Generated $(README_FILE) from $(README_TEMPLATE_FILE) probably using data from $${README_YAML}"
 
 readme/generate-related-references:
 	@$(BUILD_HARNESS_PATH)/bin/generate_related_references.py

--- a/modules/terraform/Makefile
+++ b/modules/terraform/Makefile
@@ -1,6 +1,6 @@
 TMP ?= /tmp
 TERRAFORM ?= $(BUILD_HARNESS_PATH)/vendor/terraform
-TERRAFORM_VERSION ?= 1.0.11
+TERRAFORM_VERSION ?= 1.5.7
 TERRAFORM_URL ?= https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/terraform_$(TERRAFORM_VERSION)_$(OS)_$(BUILD_HARNESS_ARCH).zip
 
 .PHONY: terraform/install terraform/get-plugins terraform/get-modules terraform/validate terraform/tflint terraform/lint


### PR DESCRIPTION
## what

- Upgrade go 1.20.13 to 1.21.7 
- Upgrade terraform 1.0.11 to 1.5.7

## why

- `go` 1.21.7 is the current stable version, and is needed by `test-harness` to run current `terratest` tests
- `terraform` 1.5.7 has many features used by Cloud Posse modules that are not available in 1.0.11, while being still licensed under a standard open source license

