### PR TITLE
Ignore lockfiles while building Terraform docs

### DIFF
--- a/modules/docs/Makefile
+++ b/modules/docs/Makefile
@@ -18,7 +18,7 @@ docs/targets.md: docs/deps
 ## Update `docs/terraform.md` from `terraform-docs`
 docs/terraform.md: docs/deps packages/install/terraform-docs
 	@echo "<!-- markdownlint-disable -->" > $@ ; \
-	terraform-docs md . >> $@ ; \
+	terraform-docs --lockfile=false md . >> $@ ; \
 	echo "<!-- markdownlint-restore -->" >> $@
 
 .PHONY : docs/github-action.md


### PR DESCRIPTION
## what

- Ignore lockfiles while building Terraform docs

## why

- By default, `terraform-docs` takes into account any version pinning present in the automatically generated `.terraform.lock.hcl`. However, Cloud Posse modules do not use the lock files for version pinning, which means that different people can get different results when creating the documentation, which causes problems. By ignoring the lock files, we make the documentation easier to reproduce.

