### PR TITLE
[readme] Fix includes

### DIFF
--- a/modules/readme/Makefile
+++ b/modules/readme/Makefile
@@ -10,7 +10,7 @@ export README_TEMPLATE_REPO_URL := https://raw.githubusercontent.com/$(README_TE
 export README_TEMPLATE_REMOTE_FILE ?= $(BUILD_HARNESS_PATH)/templates/README.md.gotmpl
 export README_TEMPLATE_FILE ?= $(README_TEMPLATE_REMOTE_FILE)
 export README_TEMPLATE_YAML := $(BUILD_HARNESS_PATH)/templates/$(README_YAML)
-export README_INCLUDES ?= ./
+export README_INCLUDES ?= "./"
 
 # Only allow allowlisted orgs to supply the README template
 export README_ALLOWLIST_ORGS := \

--- a/modules/readme/Makefile
+++ b/modules/readme/Makefile
@@ -10,6 +10,7 @@ export README_TEMPLATE_REPO_URL := https://raw.githubusercontent.com/$(README_TE
 export README_TEMPLATE_REMOTE_FILE ?= $(BUILD_HARNESS_PATH)/templates/README.md.gotmpl
 export README_TEMPLATE_FILE ?= $(README_TEMPLATE_REMOTE_FILE)
 export README_TEMPLATE_YAML := $(BUILD_HARNESS_PATH)/templates/$(README_YAML)
+export README_INCLUDES ?= ./
 
 # Only allow allowlisted orgs to supply the README template
 export README_ALLOWLIST_ORGS := \

--- a/modules/readme/Makefile
+++ b/modules/readme/Makefile
@@ -10,7 +10,7 @@ export README_TEMPLATE_REPO_URL := https://raw.githubusercontent.com/$(README_TE
 export README_TEMPLATE_REMOTE_FILE ?= $(BUILD_HARNESS_PATH)/templates/README.md.gotmpl
 export README_TEMPLATE_FILE ?= $(README_TEMPLATE_REMOTE_FILE)
 export README_TEMPLATE_YAML := $(BUILD_HARNESS_PATH)/templates/$(README_YAML)
-export README_INCLUDES ?= "./"
+export README_INCLUDES := "./"
 
 # Only allow allowlisted orgs to supply the README template
 export README_ALLOWLIST_ORGS := \

--- a/modules/readme/Makefile
+++ b/modules/readme/Makefile
@@ -10,7 +10,7 @@ export README_TEMPLATE_REPO_URL := https://raw.githubusercontent.com/$(README_TE
 export README_TEMPLATE_REMOTE_FILE ?= $(BUILD_HARNESS_PATH)/templates/README.md.gotmpl
 export README_TEMPLATE_FILE ?= $(README_TEMPLATE_REMOTE_FILE)
 export README_TEMPLATE_YAML := $(BUILD_HARNESS_PATH)/templates/$(README_YAML)
-export README_INCLUDES := $(shell pwd)
+export README_INCLUDES ?= ./
 
 # Only allow allowlisted orgs to supply the README template
 export README_ALLOWLIST_ORGS := \

--- a/modules/readme/Makefile
+++ b/modules/readme/Makefile
@@ -10,7 +10,7 @@ export README_TEMPLATE_REPO_URL := https://raw.githubusercontent.com/$(README_TE
 export README_TEMPLATE_REMOTE_FILE ?= $(BUILD_HARNESS_PATH)/templates/README.md.gotmpl
 export README_TEMPLATE_FILE ?= $(README_TEMPLATE_REMOTE_FILE)
 export README_TEMPLATE_YAML := $(BUILD_HARNESS_PATH)/templates/$(README_YAML)
-export README_INCLUDES := "./"
+export README_INCLUDES := $(shell pwd)
 
 # Only allow allowlisted orgs to supply the README template
 export README_ALLOWLIST_ORGS := \


### PR DESCRIPTION
## what
* Added explicit default value for `README_INCLUDES` environment variables

## why
* Starting from [gomplate `4.2.0`](https://github.com/hairyhenderson/gomplate/releases/tag/v4.2.0) includes required implicit definition starting with "./" or "/"
 
## references
* https://sweetops.slack.com/archives/CUJPCP1K6/p1731416487743859
* https://github.com/cloudposse/terraform-aws-alb/actions/runs/11795616491/job/32869718771
* https://github.com/hairyhenderson/gomplate/pull/2255
